### PR TITLE
docs: refresh stale markdown content

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -75,7 +75,7 @@ If you need help with Andy Tools:
 
 ## Contributing
 
-We welcome contributions! Please see our [Contributing Guide](../CONTRIBUTING.md) for details on:
+We welcome contributions! Please see the [Contributing section](../README.md#contributing) of the main README for details on:
 
 - Code style and standards
 - Testing requirements


### PR DESCRIPTION
## Summary

Markdown sweep targeting fact-level staleness. Out of scope: license headers, prose/style, section reorganization, generated docs.

- `docs/README.md`: the Contributing link pointed at `../CONTRIBUTING.md`, which does not exist in the repo. Redirected the link to the Contributing section of the root `README.md`, which does contain the equivalent guidance.

The rest of the markdown corpus (root README, getting-started, examples, tools-reference, container guides) was cross-checked against the actual tool implementations under `src/Andy.Tools/Library/` and against `container/` directory contents — no other broken paths, missing classes, or wrong-version references found. The architecture diagram in the root README is slightly summarized (no Common/Utilities/Git buckets) but the listed Built-in Tools all map to real classes.

## Test plan

- [ ] CI passes
- [ ] Click the Contributing link in `docs/README.md` and verify it lands on the README contributing section