### PR TITLE
Add ExecuteCommandTool (real shell execution) for the permission-gated bash capability

### DIFF
--- a/src/Andy.Tools/Library/BuiltInToolsExtensions.cs
+++ b/src/Andy.Tools/Library/BuiltInToolsExtensions.cs
@@ -78,6 +78,7 @@ public static class BuiltInToolsExtensions
     {
         services.AddTool<SystemInfoTool>();
         services.AddTool<ProcessInfoTool>();
+        services.AddTool<ExecuteCommandTool>();
 
         return services;
     }
@@ -243,6 +244,7 @@ public static class BuiltInToolsExtensions
             // System Tools
             ["system_info"] = typeof(SystemInfoTool),
             ["process_info"] = typeof(ProcessInfoTool),
+            ["execute_command"] = typeof(ExecuteCommandTool),
 
             // Web Tools
             ["http_request"] = typeof(HttpRequestTool),

--- a/src/Andy.Tools/Library/System/ExecuteCommandTool.cs
+++ b/src/Andy.Tools/Library/System/ExecuteCommandTool.cs
@@ -1,0 +1,243 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text;
+using Andy.Tools.Core;
+using Andy.Tools.Library.Common;
+
+namespace Andy.Tools.Library.System;
+
+/// <summary>
+/// Executes a shell command and returns its exit code, stdout, and stderr. This is a high-privilege tool:
+/// it declares the <see cref="ToolCapability.ProcessExecution"/> capability and requires confirmation, so
+/// when used behind the Andy.Permissions consent layer it defaults to Ask unless an explicit allow rule
+/// matches. The command string is passed as a single argument to the shell (<c>bash -c</c> /
+/// <c>cmd /c</c>); no extra wrapping is performed.
+/// </summary>
+public class ExecuteCommandTool : ToolBase
+{
+    private const int DefaultTimeoutSeconds = 120;
+    private const int MaxStreamChars = 1_000_000;
+
+    /// <inheritdoc />
+    public override ToolMetadata Metadata { get; } = new()
+    {
+        Id = "execute_command",
+        Name = "Execute Command",
+        Description = "Executes a shell command and returns its exit code, standard output, and standard error.",
+        Version = "1.0.0",
+        Category = ToolCategory.System,
+        RequiredPermissions = ToolPermissionFlags.ProcessExecution,
+        RequiredCapabilities = ToolCapability.ProcessExecution,
+        RequiresConfirmation = true,
+        Parameters =
+        [
+            new()
+            {
+                Name = "command",
+                Description = "The shell command to execute.",
+                Type = "string",
+                Required = true,
+            },
+            new()
+            {
+                Name = "working_directory",
+                Description = "Directory to run the command in (defaults to the execution context working directory).",
+                Type = "string",
+                Required = false,
+            },
+            new()
+            {
+                Name = "timeout_seconds",
+                Description = "Maximum seconds to allow the command to run before it is killed (default: 120).",
+                Type = "integer",
+                Required = false,
+                DefaultValue = DefaultTimeoutSeconds,
+            },
+        ],
+    };
+
+    /// <inheritdoc />
+    protected override async Task<ToolResult> ExecuteInternalAsync(Dictionary<string, object?> parameters, ToolExecutionContext context)
+    {
+        var command = GetParameter<string>(parameters, "command");
+        if (string.IsNullOrWhiteSpace(command))
+        {
+            return ToolResult.Failure("Parameter 'command' is required and cannot be empty.");
+        }
+
+        var timeoutSeconds = GetParameter(parameters, "timeout_seconds", DefaultTimeoutSeconds);
+        if (timeoutSeconds <= 0)
+        {
+            timeoutSeconds = DefaultTimeoutSeconds;
+        }
+
+        var workingDirectory = GetParameter<string?>(parameters, "working_directory", null)
+            ?? context.WorkingDirectory;
+        if (!string.IsNullOrEmpty(workingDirectory))
+        {
+            workingDirectory = ToolHelpers.GetSafePath(workingDirectory, context.WorkingDirectory);
+            if (!Directory.Exists(workingDirectory))
+            {
+                return ToolResult.Failure($"Working directory does not exist: {workingDirectory}");
+            }
+        }
+
+        var psi = BuildShellStartInfo(command);
+        if (!string.IsNullOrEmpty(workingDirectory))
+        {
+            psi.WorkingDirectory = workingDirectory;
+        }
+
+        foreach (var kvp in context.Environment)
+        {
+            psi.Environment[kvp.Key] = kvp.Value;
+        }
+
+        using var process = new Process { StartInfo = psi };
+        var stdout = new StringBuilder();
+        var stderr = new StringBuilder();
+        process.OutputDataReceived += (_, e) => AppendCapped(stdout, e.Data);
+        process.ErrorDataReceived += (_, e) => AppendCapped(stderr, e.Data);
+
+        var stopwatch = Stopwatch.StartNew();
+
+        try
+        {
+            process.Start();
+        }
+        catch (Exception ex)
+        {
+            return ToolResult.Failure($"Failed to start command: {ex.Message}");
+        }
+
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+
+        using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(timeoutSeconds));
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(context.CancellationToken, timeoutCts.Token);
+
+        var timedOut = false;
+        try
+        {
+            await process.WaitForExitAsync(linkedCts.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            KillProcessTree(process);
+            if (context.CancellationToken.IsCancellationRequested)
+            {
+                throw; // genuine cancellation — let ToolBase report it
+            }
+
+            timedOut = true;
+        }
+
+        stopwatch.Stop();
+
+        // Drain any final buffered output.
+        try { process.WaitForExit(500); } catch { /* best effort */ }
+
+        var exitCode = timedOut ? -1 : SafeExitCode(process);
+        var data = new Dictionary<string, object?>
+        {
+            ["command"] = command,
+            ["exit_code"] = exitCode,
+            ["stdout"] = stdout.ToString(),
+            ["stderr"] = stderr.ToString(),
+            ["duration_ms"] = stopwatch.Elapsed.TotalMilliseconds,
+            ["timed_out"] = timedOut,
+            ["working_directory"] = workingDirectory,
+        };
+
+        if (timedOut)
+        {
+            return new ToolResult
+            {
+                IsSuccessful = false,
+                Data = data,
+                ErrorMessage = $"Command timed out after {timeoutSeconds}s and was terminated.",
+                DurationMs = stopwatch.Elapsed.TotalMilliseconds,
+            };
+        }
+
+        return new ToolResult
+        {
+            IsSuccessful = exitCode == 0,
+            Data = data,
+            ErrorMessage = exitCode == 0 ? null : $"Command exited with code {exitCode}.",
+            DurationMs = stopwatch.Elapsed.TotalMilliseconds,
+        };
+    }
+
+    private static ProcessStartInfo BuildShellStartInfo(string command)
+    {
+        var psi = new ProcessStartInfo
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            psi.FileName = Environment.GetEnvironmentVariable("ComSpec") ?? "cmd.exe";
+            psi.ArgumentList.Add("/c");
+            psi.ArgumentList.Add(command);
+        }
+        else
+        {
+            psi.FileName = File.Exists("/bin/bash") ? "/bin/bash" : "/bin/sh";
+            psi.ArgumentList.Add("-c");
+            psi.ArgumentList.Add(command);
+        }
+
+        return psi;
+    }
+
+    private static void AppendCapped(StringBuilder sb, string? data)
+    {
+        if (data is null || sb.Length >= MaxStreamChars)
+        {
+            return;
+        }
+
+        var remaining = MaxStreamChars - sb.Length;
+        if (data.Length + 1 > remaining)
+        {
+            sb.Append(data.AsSpan(0, Math.Max(0, remaining - 1)));
+            sb.Append("\n…[output truncated]");
+        }
+        else
+        {
+            sb.AppendLine(data);
+        }
+    }
+
+    private static int SafeExitCode(Process process)
+    {
+        try
+        {
+            return process.ExitCode;
+        }
+        catch
+        {
+            return -1;
+        }
+    }
+
+    private static void KillProcessTree(Process process)
+    {
+        try
+        {
+            if (!process.HasExited)
+            {
+                process.Kill(entireProcessTree: true);
+            }
+        }
+        catch
+        {
+            // best effort
+        }
+    }
+}

--- a/tests/Andy.Tools.Tests/Library/System/ExecuteCommandToolTests.cs
+++ b/tests/Andy.Tools.Tests/Library/System/ExecuteCommandToolTests.cs
@@ -1,0 +1,161 @@
+using Andy.Tools.Core;
+using Andy.Tools.Library.System;
+using Xunit;
+
+namespace Andy.Tools.Tests.Library.System;
+
+public class ExecuteCommandToolTests
+{
+    private readonly ExecuteCommandTool _tool;
+
+    public ExecuteCommandToolTests()
+    {
+        _tool = new ExecuteCommandTool();
+        _tool.InitializeAsync().GetAwaiter().GetResult();
+    }
+
+    private static ToolExecutionContext Context(string? workingDir = null) => new()
+    {
+        WorkingDirectory = workingDir,
+        Permissions = new ToolPermissions { ProcessExecution = true },
+    };
+
+    private static Dictionary<string, object?> P(params (string, object?)[] kv) =>
+        kv.ToDictionary(x => x.Item1, x => x.Item2);
+
+    [Fact]
+    public void Metadata_declares_process_execution_and_confirmation()
+    {
+        Assert.Equal("execute_command", _tool.Metadata.Id);
+        Assert.True(_tool.Metadata.RequiresConfirmation);
+        Assert.True(_tool.Metadata.RequiredCapabilities.HasFlag(ToolCapability.ProcessExecution));
+        Assert.True(_tool.Metadata.RequiredPermissions.HasFlag(ToolPermissionFlags.ProcessExecution));
+    }
+
+    [Fact]
+    public async Task Echo_returns_stdout_and_zero_exit()
+    {
+        var result = await _tool.ExecuteAsync(P(("command", "echo hello_world")), Context());
+
+        Assert.True(result.IsSuccessful, result.ErrorMessage);
+        var data = Assert.IsType<Dictionary<string, object?>>(result.Data);
+        Assert.Equal(0, data["exit_code"]);
+        Assert.Contains("hello_world", (string)data["stdout"]!);
+    }
+
+    [Fact]
+    public async Task Nonzero_exit_is_reported_as_failure_with_code()
+    {
+        var result = await _tool.ExecuteAsync(P(("command", "exit 3")), Context());
+
+        Assert.False(result.IsSuccessful);
+        var data = Assert.IsType<Dictionary<string, object?>>(result.Data);
+        Assert.Equal(3, data["exit_code"]);
+    }
+
+    [Fact]
+    public async Task Missing_process_execution_permission_is_denied()
+    {
+        var ctx = new ToolExecutionContext { Permissions = new ToolPermissions { ProcessExecution = false } };
+        var result = await _tool.ExecuteAsync(P(("command", "echo hi")), ctx);
+
+        Assert.False(result.IsSuccessful);
+        Assert.Contains("permission", result.ErrorMessage!, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Empty_command_fails_validation()
+    {
+        var result = await _tool.ExecuteAsync(P(("command", "")), Context());
+        Assert.False(result.IsSuccessful);
+    }
+
+    [Fact]
+    public async Task Nonexistent_working_directory_fails()
+    {
+        var missing = Path.Combine(Path.GetTempPath(), "andy-no-such-" + Guid.NewGuid().ToString("N"));
+        var result = await _tool.ExecuteAsync(P(("command", "echo hi"), ("working_directory", missing)), Context());
+
+        Assert.False(result.IsSuccessful);
+        Assert.Contains("working directory", result.ErrorMessage!, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Runs_in_specified_working_directory()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return; // pwd is POSIX; covered on Linux/macOS CI legs
+        }
+
+        var dir = Path.Combine(Path.GetTempPath(), "andy-wd-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var result = await _tool.ExecuteAsync(P(("command", "pwd"), ("working_directory", dir)), Context());
+            Assert.True(result.IsSuccessful, result.ErrorMessage);
+            var data = (Dictionary<string, object?>)result.Data!;
+            // macOS resolves /var/folders/... via /private symlink; match on the leaf.
+            Assert.Contains(Path.GetFileName(dir), (string)data["stdout"]!);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Timeout_terminates_long_command()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return; // sleep is POSIX; covered on Linux/macOS CI legs
+        }
+
+        var result = await _tool.ExecuteAsync(P(("command", "sleep 10"), ("timeout_seconds", 1)), Context());
+
+        Assert.False(result.IsSuccessful);
+        var data = (Dictionary<string, object?>)result.Data!;
+        Assert.True((bool)data["timed_out"]!);
+    }
+
+    [Fact]
+    public async Task Cancellation_is_reported()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        using var cts = new CancellationTokenSource();
+        var ctx = new ToolExecutionContext
+        {
+            Permissions = new ToolPermissions { ProcessExecution = true },
+            CancellationToken = cts.Token,
+        };
+        cts.CancelAfter(200);
+
+        var result = await _tool.ExecuteAsync(P(("command", "sleep 10")), ctx);
+        Assert.False(result.IsSuccessful);
+    }
+
+    [Fact]
+    public async Task Environment_variables_are_passed_through()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return; // ${VAR} expansion is shell-specific
+        }
+
+        var ctx = new ToolExecutionContext
+        {
+            Permissions = new ToolPermissions { ProcessExecution = true },
+            Environment = { ["ANDY_TEST_VAR"] = "andyval123" },
+        };
+
+        var result = await _tool.ExecuteAsync(P(("command", "echo $ANDY_TEST_VAR")), ctx);
+        Assert.True(result.IsSuccessful, result.ErrorMessage);
+        var data = (Dictionary<string, object?>)result.Data!;
+        Assert.Contains("andyval123", (string)data["stdout"]!);
+    }
+}


### PR DESCRIPTION
Phase 2 of the tool permission system (epic rivoli-ai/andy-engine#5, issue rivoli-ai/andy-engine#7).

## What
Adds `execute_command`, a real shell-execution tool, to `Andy.Tools.Library.System`:
- Runs the command via `bash -c` (POSIX) or `cmd /c` (Windows); the command is passed as a single
  argv entry — no extra shell wrapping.
- Returns structured data: `exit_code`, `stdout`, `stderr`, `duration_ms`, `timed_out`, `working_directory`.
- Honors `working_directory` (validated, path-safe), per-call `timeout_seconds` (default 120, kills the
  process tree on timeout), context cancellation, and context environment variables. Captured output is
  capped to avoid memory blowup.
- **High-privilege by design:** declares `ToolCapability.ProcessExecution` + `RequiresConfirmation = true`
  and `ToolPermissionFlags.ProcessExecution`. Behind the `Andy.Permissions` consent layer this defaults
  to **Ask** unless an explicit allow rule matches; without `ProcessExecution` permission it is denied.
- Registered in the built-in catalog (`AddSystemTools` + the id map).

## Tests
10 cross-platform tests (`ExecuteCommandToolTests`): echo/stdout, non-zero exit, missing-permission
denial, empty command, missing working dir, working-dir honored, timeout, cancellation, env passthrough,
metadata. Full suite green: **842 passing**.

## Deliberately out of scope
`SecurityManager`'s hardcoded `bash`/`sh` entry in `IsProcessExecutionAllowed` is a helper consulted
only when a caller invokes it explicitly — it is not on the executor path and does not gate this tool.
Unifying it with the permission layer (single violation path) is deferred to the seam-upstreaming phase
(RD-A5 in the design doc). The display-only `bash_command` tool in andy-cli is replaced in Phase 3.