### PR TITLE
Add optional IToolPermissionGate consulted by ToolExecutor (built-in permission seam)

### DIFF
--- a/src/Andy.Tools/Core/IToolPermissionGate.cs
+++ b/src/Andy.Tools/Core/IToolPermissionGate.cs
@@ -1,0 +1,46 @@
+namespace Andy.Tools.Core;
+
+/// <summary>
+/// Optional consent gate consulted by <see cref="IToolExecutor"/> before a tool runs. When no
+/// implementation is registered in DI, the executor behaves exactly as before (no gating). A permission
+/// system (e.g. Andy.Permissions) registers an implementation that authorizes the call against its rules
+/// and, where needed, prompts for consent — returning a single allow/deny verdict so the executor itself
+/// stays unaware of rules, layers, or prompts.
+/// </summary>
+public interface IToolPermissionGate
+{
+    /// <summary>Decides whether a tool call may proceed. Returns a verdict; never throws for a denial.</summary>
+    public Task<ToolPermissionVerdict> CheckAsync(ToolPermissionGateRequest request, CancellationToken cancellationToken = default);
+}
+
+/// <summary>The information the gate needs to decide a tool call.</summary>
+public sealed class ToolPermissionGateRequest
+{
+    /// <summary>The id of the tool being invoked.</summary>
+    public required string ToolId { get; init; }
+
+    /// <summary>The tool call parameters (used to resolve the governed resources).</summary>
+    public required IReadOnlyDictionary<string, object?> Parameters { get; init; }
+
+    /// <summary>The execution context (working directory, cancellation, permissions, …).</summary>
+    public required ToolExecutionContext Context { get; init; }
+
+    /// <summary>The tool's metadata, used for capability/confirmation fallback. May be null.</summary>
+    public ToolMetadata? Metadata { get; init; }
+}
+
+/// <summary>The result of a <see cref="IToolPermissionGate"/> check.</summary>
+public sealed class ToolPermissionVerdict
+{
+    /// <summary>True if the call may proceed.</summary>
+    public bool Allowed { get; init; }
+
+    /// <summary>Human-readable reason when denied (surfaced to the model as the tool error).</summary>
+    public string? Reason { get; init; }
+
+    /// <summary>A shared "allowed" verdict.</summary>
+    public static ToolPermissionVerdict Allow { get; } = new() { Allowed = true };
+
+    /// <summary>Creates a denial verdict with a reason.</summary>
+    public static ToolPermissionVerdict Deny(string reason) => new() { Allowed = false, Reason = reason };
+}

--- a/src/Andy.Tools/Execution/ToolExecutor.cs
+++ b/src/Andy.Tools/Execution/ToolExecutor.cs
@@ -20,6 +20,7 @@ public class ToolExecutor : IToolExecutor, IDisposable
     private readonly IResourceMonitor _resourceMonitor;
     private readonly IToolOutputLimiter _outputLimiter;
     private readonly IToolObservabilityService? _observabilityService;
+    private readonly IToolPermissionGate? _permissionGate;
     private readonly IServiceProvider _serviceProvider;
     private readonly ILogger<ToolExecutor> _logger;
     private readonly ConcurrentDictionary<string, CancellationTokenSource> _runningExecutions = new();
@@ -56,6 +57,9 @@ public class ToolExecutor : IToolExecutor, IDisposable
 
         // Try to get observability service (optional)
         _observabilityService = serviceProvider.GetService<IToolObservabilityService>();
+
+        // Try to get the permission consent gate (optional; null ⇒ no gating, original behavior).
+        _permissionGate = serviceProvider.GetService<IToolPermissionGate>();
 
         // Subscribe to resource limit events
         _resourceMonitor.ResourceLimitExceeded += OnResourceLimitExceeded;
@@ -148,6 +152,35 @@ public class ToolExecutor : IToolExecutor, IDisposable
                         SecurityViolation?.Invoke(this, new SecurityViolationEventArgs(request.ToolId, correlationId, violation, SecurityViolationSeverity.High));
                     }
 
+                    return result;
+                }
+            }
+
+            // Permission consent gate (optional). Applies regardless of EnforcePermissions: it is the
+            // consent layer, distinct from the SecurityManager capability check above. No gate ⇒ no-op.
+            if (_permissionGate != null)
+            {
+                var verdict = await _permissionGate.CheckAsync(
+                    new ToolPermissionGateRequest
+                    {
+                        ToolId = request.ToolId,
+                        Parameters = request.Parameters,
+                        Context = request.Context,
+                        Metadata = registration.Metadata,
+                    },
+                    request.Context.CancellationToken);
+
+                if (!verdict.Allowed)
+                {
+                    var reason = verdict.Reason ?? $"Tool '{request.ToolId}' blocked by permission policy";
+                    result.IsSuccessful = false;
+                    result.ErrorMessage = reason;
+                    result.SecurityViolations = [reason];
+                    result.EndTime = DateTimeOffset.UtcNow;
+
+                    _securityManager.RecordViolation(request.ToolId, correlationId, reason, SecurityViolationSeverity.High);
+                    SecurityViolation?.Invoke(this, new SecurityViolationEventArgs(request.ToolId, correlationId, reason, SecurityViolationSeverity.High));
+                    ExecutionCompleted?.Invoke(this, new ToolExecutionCompletedEventArgs(result));
                     return result;
                 }
             }

--- a/tests/Andy.Tools.Tests/Execution/ToolExecutorPermissionGateTests.cs
+++ b/tests/Andy.Tools.Tests/Execution/ToolExecutorPermissionGateTests.cs
@@ -1,0 +1,106 @@
+using Andy.Tools.Core;
+using Andy.Tools.Core.OutputLimiting;
+using Andy.Tools.Execution;
+using Andy.Tools.Validation;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Andy.Tools.Tests.Execution;
+
+public class ToolExecutorPermissionGateTests
+{
+    private sealed class FakeGate : IToolPermissionGate
+    {
+        private readonly ToolPermissionVerdict _verdict;
+        public int Calls;
+        public FakeGate(ToolPermissionVerdict verdict) => _verdict = verdict;
+        public Task<ToolPermissionVerdict> CheckAsync(ToolPermissionGateRequest request, CancellationToken cancellationToken = default)
+        {
+            Calls++;
+            return Task.FromResult(_verdict);
+        }
+    }
+
+    private static (ToolExecutor Exec, Mock<ITool> Tool) Build(IToolPermissionGate? gate)
+    {
+        var registry = new Mock<IToolRegistry>();
+        var validator = new Mock<IToolValidator>();
+        var security = new Mock<ISecurityManager>();
+        var monitor = new Mock<IResourceMonitor>();
+        var limiter = new Mock<IToolOutputLimiter>();
+        var sp = new Mock<IServiceProvider>();
+        var logger = new Mock<ILogger<ToolExecutor>>();
+        var tool = new Mock<ITool>();
+
+        var registration = new ToolRegistration
+        {
+            Metadata = new ToolMetadata { Id = "demo", Name = "Demo" },
+            IsEnabled = true,
+        };
+        registry.Setup(x => x.GetTool("demo")).Returns(registration);
+        registry.Setup(x => x.CreateTool("demo", It.IsAny<IServiceProvider>())).Returns(tool.Object);
+
+        tool.Setup(t => t.InitializeAsync(It.IsAny<Dictionary<string, object?>>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        tool.Setup(t => t.ExecuteAsync(It.IsAny<Dictionary<string, object?>>(), It.IsAny<ToolExecutionContext>()))
+            .ReturnsAsync(ToolResult.Success("ok"));
+        limiter.Setup(x => x.NeedsLimiting(It.IsAny<object?>(), It.IsAny<OutputType>())).Returns(false);
+        sp.Setup(x => x.GetService(typeof(IToolPermissionGate))).Returns(gate!);
+
+        var exec = new ToolExecutor(registry.Object, validator.Object, security.Object, monitor.Object, limiter.Object, sp.Object, logger.Object);
+        return (exec, tool);
+    }
+
+    private static ToolExecutionRequest Req() => new()
+    {
+        ToolId = "demo",
+        Parameters = new Dictionary<string, object?>(),
+        Context = new ToolExecutionContext(),
+        ValidateParameters = false,
+        EnforcePermissions = false,
+        EnforceResourceLimits = false,
+    };
+
+    [Fact]
+    public async Task Gate_deny_blocks_execution_and_reports_violation()
+    {
+        var gate = new FakeGate(ToolPermissionVerdict.Deny("blocked by policy"));
+        var (exec, tool) = Build(gate);
+        SecurityViolationEventArgs? violation = null;
+        exec.SecurityViolation += (_, e) => violation = e;
+
+        var result = await exec.ExecuteAsync(Req());
+
+        Assert.False(result.IsSuccessful);
+        Assert.Contains("blocked by policy", result.ErrorMessage);
+        Assert.NotEmpty(result.SecurityViolations);
+        Assert.Equal(1, gate.Calls);
+        Assert.NotNull(violation);
+        tool.Verify(t => t.ExecuteAsync(It.IsAny<Dictionary<string, object?>>(), It.IsAny<ToolExecutionContext>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Gate_allow_runs_the_tool()
+    {
+        var gate = new FakeGate(ToolPermissionVerdict.Allow);
+        var (exec, tool) = Build(gate);
+
+        var result = await exec.ExecuteAsync(Req());
+
+        Assert.True(result.IsSuccessful, result.ErrorMessage);
+        Assert.Equal(1, gate.Calls);
+        tool.Verify(t => t.ExecuteAsync(It.IsAny<Dictionary<string, object?>>(), It.IsAny<ToolExecutionContext>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task No_gate_registered_is_a_no_op()
+    {
+        var (exec, tool) = Build(gate: null);
+
+        var result = await exec.ExecuteAsync(Req());
+
+        Assert.True(result.IsSuccessful, result.ErrorMessage);
+        tool.Verify(t => t.ExecuteAsync(It.IsAny<Dictionary<string, object?>>(), It.IsAny<ToolExecutionContext>()), Times.Once);
+    }
+}


### PR DESCRIPTION
Phase 5 of the permission rollout (rivoli-ai/andy-engine#10): make permission consent a first-class, built-in step rather than an external decorator.

## What
- **New `Andy.Tools.Core.IToolPermissionGate`** (+ `ToolPermissionGateRequest`, `ToolPermissionVerdict`): a single allow/deny seam. The executor stays unaware of rules/layers/prompts — the gate implementation (Andy.Permissions) handles all that and returns a verdict.
- **`ToolExecutor`** resolves `IToolPermissionGate` from DI (optional). When present it is checked before the tool runs (regardless of `EnforcePermissions` — consent is distinct from the `SecurityManager` capability check). A denial returns a failure `ToolExecutionResult`, records a violation, and raises `SecurityViolation` + `ExecutionCompleted`. **When absent, behavior is unchanged** — fully backward compatible.

## Tests
`ToolExecutorPermissionGateTests`: deny blocks execution + reports a violation; allow runs the tool; **no gate registered is a no-op**. Gate tests green.

## CI note
The full suite has one pre-existing flaky failure (`WriteFileToolTests.ExecuteAsync_PathOutsideAllowed_ReturnsError`) — it passes in isolation; it races other tests on a shared `$TMPDIR/outside.txt`. Unrelated to this additive change (the gate is null in every existing test). Same class of pre-existing flake as the long-red Windows `DeleteFileTool` test.

Next: Andy.Permissions implements `IToolPermissionGate` and stops decorating; then andy-cli/andy-engine bump to the built-in gate.