### PR TITLE
Fix UTF-8 file writes emitting a spurious BOM

### DIFF
--- a/src/Andy.Tools/Library/Common/ToolHelpers.cs
+++ b/src/Andy.Tools/Library/Common/ToolHelpers.cs
@@ -13,6 +13,20 @@ namespace Andy.Tools.Library.Common;
 public static class ToolHelpers
 {
     /// <summary>
+    /// UTF-8 encoding that does NOT emit a byte-order mark.
+    /// <para>
+    /// The framework's <see cref="Encoding.UTF8"/> singleton is configured with
+    /// <c>encoderShouldEmitUTF8Identifier: true</c>, so passing it to
+    /// <see cref="File.WriteAllTextAsync(string, string?, Encoding, CancellationToken)"/>
+    /// prepends an <c>EF BB BF</c> BOM. For source files that originally had no BOM
+    /// that silently corrupts the file (a spurious leading character that breaks
+    /// diffs, patches, and tooling). Use this instance for all UTF-8 file writes so
+    /// non-BOM files stay non-BOM.
+    /// </para>
+    /// </summary>
+    public static readonly Encoding Utf8NoBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+
+    /// <summary>
     /// Safely converts a path to an absolute path, ensuring it exists within allowed boundaries.
     /// </summary>
     /// <param name="path">The input path.</param>
@@ -155,7 +169,7 @@ public static class ToolHelpers
     /// <param name="cancellationToken">Cancellation token.</param>
     public static async Task WriteTextFileAsync(string filePath, string content, Encoding? encoding = null, bool createBackup = true, CancellationToken cancellationToken = default)
     {
-        encoding ??= Encoding.UTF8;
+        encoding ??= Utf8NoBom;
 
         // Create backup if file exists and backup is requested
         if (createBackup && File.Exists(filePath))
@@ -189,7 +203,9 @@ public static class ToolHelpers
             Array.Resize(ref buffer, bytesRead);
         }
 
-        // Check for BOM
+        // Check for BOM. Only when the file actually starts with a UTF-8 BOM do we
+        // return the BOM-emitting Encoding.UTF8, so a rewrite preserves it. Files
+        // without a BOM fall through to Utf8NoBom below and stay BOM-free.
         if (bytesRead >= 3 && buffer[0] == 0xEF && buffer[1] == 0xBB && buffer[2] == 0xBF)
         {
             return Encoding.UTF8;
@@ -210,7 +226,7 @@ public static class ToolHelpers
             return Encoding.BigEndianUnicode; // UTF-16 BE
         }
 
-        return Encoding.UTF8; // Default to UTF-8
+        return Utf8NoBom; // Default to UTF-8 without a BOM
     }
 
     /// <summary>

--- a/src/Andy.Tools/Library/FileSystem/WriteFileTool.cs
+++ b/src/Andy.Tools/Library/FileSystem/WriteFileTool.cs
@@ -106,7 +106,9 @@ public class WriteFileTool : ToolBase
             // Determine encoding
             var encoding = encodingName.ToLowerInvariant() switch
             {
-                "utf-8" => Encoding.UTF8,
+                // No-BOM UTF-8: writing Encoding.UTF8 would prepend an EF BB BF BOM
+                // and corrupt files that had none (breaking diffs/patches).
+                "utf-8" => ToolHelpers.Utf8NoBom,
                 "ascii" => Encoding.ASCII,
                 "unicode" or "utf-16" => Encoding.Unicode,
                 "utf-32" => Encoding.UTF32,

--- a/src/Andy.Tools/Library/Text/ReplaceTextTool.cs
+++ b/src/Andy.Tools/Library/Text/ReplaceTextTool.cs
@@ -296,7 +296,8 @@ public class ReplaceTextTool : ToolBase
             Encoding encoding = !string.IsNullOrEmpty(encodingName)
                 ? encodingName.ToLowerInvariant() switch
                 {
-                    "utf-8" => Encoding.UTF8,
+                    // No-BOM UTF-8: see WriteFileTool — Encoding.UTF8 emits a BOM.
+                    "utf-8" => ToolHelpers.Utf8NoBom,
                     "ascii" => Encoding.ASCII,
                     "unicode" or "utf-16" => Encoding.Unicode,
                     "utf-32" => Encoding.UTF32,

--- a/tests/Andy.Tools.Tests/Library/FileSystem/WriteFileToolBomTests.cs
+++ b/tests/Andy.Tools.Tests/Library/FileSystem/WriteFileToolBomTests.cs
@@ -1,0 +1,95 @@
+using Andy.Tools.Core;
+using Andy.Tools.Library.FileSystem;
+using Xunit;
+
+namespace Andy.Tools.Tests.Library.FileSystem;
+
+// Regression tests: writing UTF-8 must not prepend a byte-order mark.
+// Encoding.UTF8 emits an EF BB BF BOM when handed to File.WriteAllText, which
+// silently corrupts source files that had none and breaks diffs/patches.
+public class WriteFileToolBomTests : IDisposable
+{
+    private static readonly byte[] Utf8Bom = [0xEF, 0xBB, 0xBF];
+
+    private readonly string _testDirectory;
+    private readonly WriteFileTool _tool;
+    private readonly ToolExecutionContext _context;
+
+    public WriteFileToolBomTests()
+    {
+        _testDirectory = Path.Combine(Path.GetTempPath(), $"andy_bom_test_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_testDirectory);
+
+        _tool = new WriteFileTool();
+        _tool.InitializeAsync().GetAwaiter().GetResult();
+        _context = new ToolExecutionContext
+        {
+            Permissions = new ToolPermissions { AllowedPaths = [_testDirectory] }
+        };
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_testDirectory))
+        {
+            Directory.Delete(_testDirectory, true);
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NewUtf8File_DoesNotEmitBom()
+    {
+        var filePath = Path.Combine(_testDirectory, "new.py");
+        var content = "def add(a, b):\n    return a + b\n";
+
+        var result = await _tool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["file_path"] = filePath,
+            ["content"] = content,
+        }, _context);
+
+        Assert.True(result.IsSuccessful);
+        var bytes = await File.ReadAllBytesAsync(filePath);
+        Assert.False(StartsWithBom(bytes), "write_file must not prepend a UTF-8 BOM");
+        Assert.Equal((byte)'d', bytes[0]);
+        Assert.Equal(content, await File.ReadAllTextAsync(filePath));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ExplicitUtf8_DoesNotEmitBom()
+    {
+        var filePath = Path.Combine(_testDirectory, "explicit.txt");
+
+        var result = await _tool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["file_path"] = filePath,
+            ["content"] = "hello",
+            ["encoding"] = "utf-8",
+        }, _context);
+
+        Assert.True(result.IsSuccessful);
+        var bytes = await File.ReadAllBytesAsync(filePath);
+        Assert.False(StartsWithBom(bytes));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_OverwriteNonBomFile_StaysNonBom()
+    {
+        var filePath = Path.Combine(_testDirectory, "existing.txt");
+        await File.WriteAllTextAsync(filePath, "original");
+
+        var result = await _tool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["file_path"] = filePath,
+            ["content"] = "updated",
+            ["create_backup"] = false,
+        }, _context);
+
+        Assert.True(result.IsSuccessful);
+        var bytes = await File.ReadAllBytesAsync(filePath);
+        Assert.False(StartsWithBom(bytes));
+    }
+
+    private static bool StartsWithBom(byte[] bytes)
+        => bytes.Length >= 3 && bytes[0] == Utf8Bom[0] && bytes[1] == Utf8Bom[1] && bytes[2] == Utf8Bom[2];
+}

--- a/tests/Andy.Tools.Tests/Library/Text/ReplaceTextToolBomTests.cs
+++ b/tests/Andy.Tools.Tests/Library/Text/ReplaceTextToolBomTests.cs
@@ -1,0 +1,80 @@
+using System.Text;
+using Andy.Tools.Core;
+using Andy.Tools.Library.Text;
+using Xunit;
+
+namespace Andy.Tools.Tests.Library.Text;
+
+// Regression tests: replacing text in a file must preserve its BOM-ness.
+// A non-BOM file must stay non-BOM (Encoding.UTF8 would otherwise inject an
+// EF BB BF BOM and corrupt the file / break the patch), and a file that
+// genuinely had a BOM must keep it.
+public class ReplaceTextToolBomTests : IDisposable
+{
+    private static readonly byte[] Utf8Bom = [0xEF, 0xBB, 0xBF];
+
+    private readonly string _testDirectory;
+    private readonly ReplaceTextTool _tool;
+
+    public ReplaceTextToolBomTests()
+    {
+        _testDirectory = Path.Combine(Path.GetTempPath(), $"andy_replace_bom_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_testDirectory);
+        _tool = new ReplaceTextTool();
+        _tool.InitializeAsync().GetAwaiter().GetResult();
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_testDirectory))
+        {
+            Directory.Delete(_testDirectory, true);
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NonBomFile_StaysNonBom()
+    {
+        var filePath = Path.Combine(_testDirectory, "calc.py");
+        var original = "def add(a, b):\n    return a - b\n";
+        await File.WriteAllBytesAsync(filePath, Encoding.UTF8.GetBytes(original)); // bytes only, no BOM
+
+        var result = await _tool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["search_pattern"] = "return a - b",
+            ["replacement_text"] = "return a + b",
+            ["target_path"] = filePath,
+            ["create_backup"] = false,
+        }, new ToolExecutionContext());
+
+        Assert.True(result.IsSuccessful);
+        var bytes = await File.ReadAllBytesAsync(filePath);
+        Assert.False(StartsWithBom(bytes), "replace_text must not introduce a UTF-8 BOM");
+        Assert.Equal("def add(a, b):\n    return a + b\n", await File.ReadAllTextAsync(filePath));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_FileWithBom_PreservesBom()
+    {
+        var filePath = Path.Combine(_testDirectory, "withbom.txt");
+        var bom = new List<byte>(Utf8Bom);
+        bom.AddRange(Encoding.UTF8.GetBytes("hello world"));
+        await File.WriteAllBytesAsync(filePath, bom.ToArray());
+
+        var result = await _tool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["search_pattern"] = "world",
+            ["replacement_text"] = "there",
+            ["target_path"] = filePath,
+            ["create_backup"] = false,
+        }, new ToolExecutionContext());
+
+        Assert.True(result.IsSuccessful);
+        var bytes = await File.ReadAllBytesAsync(filePath);
+        Assert.True(StartsWithBom(bytes), "a file that originally had a BOM should keep it");
+        Assert.Equal("hello there", await File.ReadAllTextAsync(filePath));
+    }
+
+    private static bool StartsWithBom(byte[] bytes)
+        => bytes.Length >= 3 && bytes[0] == Utf8Bom[0] && bytes[1] == Utf8Bom[1] && bytes[2] == Utf8Bom[2];
+}


### PR DESCRIPTION
## Summary
File writes used the framework's `Encoding.UTF8` singleton (configured with `encoderShouldEmitUTF8Identifier: true`), which prepends an `EF BB BF` BOM. For source files that originally had no BOM this silently corrupts the file (a spurious leading character that breaks diffs, patches, and tooling).

This change introduces a `ToolHelpers.Utf8NoBom` encoding and uses it for UTF-8 file writes, and makes `DetectEncoding` default non-BOM files to `Utf8NoBom` so a rewrite preserves their BOM-free state. `WriteFileTool` and `ReplaceTextTool` now write through it.

## Changes
- `ToolHelpers`: add `Utf8NoBom`; `DetectEncoding` returns it for non-BOM files; `WriteTextFileAsync` defaults to it.
- `WriteFileTool`, `ReplaceTextTool`: write using the non-BOM encoding.
- Tests: `WriteFileToolBomTests`, `ReplaceTextToolBomTests`.

## Notes
This is the **base of a stacked series of fixes** addressing the code review (issues #8–#34). Subsequent PRs build on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)