### PR TITLE
fix(security): close path-confinement prefix bypass (#8)

### DIFF
--- a/src/Andy.Tools/Execution/SecurityManager.cs
+++ b/src/Andy.Tools/Execution/SecurityManager.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Text.RegularExpressions;
 using Andy.Tools.Core;
+using Andy.Tools.Library.Common;
 using Microsoft.Extensions.Logging;
 
 namespace Andy.Tools.Execution;
@@ -119,7 +120,7 @@ public class SecurityManager : ISecurityManager
                 try
                 {
                     var normalizedBlockedPath = Path.GetFullPath(blockedPath.Replace("~", Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)));
-                    return filePath.StartsWith(normalizedBlockedPath, StringComparison.OrdinalIgnoreCase);
+                    return ToolHelpers.IsPathWithinBoundary(filePath, normalizedBlockedPath);
                 }
                 catch
                 {
@@ -141,7 +142,7 @@ public class SecurityManager : ISecurityManager
                 try
                 {
                     var normalizedAllowedPath = Path.GetFullPath(allowedPath.Replace("~", Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)));
-                    return filePath.StartsWith(normalizedAllowedPath, StringComparison.OrdinalIgnoreCase);
+                    return ToolHelpers.IsPathWithinBoundary(filePath, normalizedAllowedPath);
                 }
                 catch
                 {
@@ -166,7 +167,7 @@ public class SecurityManager : ISecurityManager
 
         foreach (var sensitiveDir in sensitiveDirectories.Where(d => !string.IsNullOrEmpty(d)))
         {
-            if (filePath.StartsWith(sensitiveDir, StringComparison.OrdinalIgnoreCase))
+            if (ToolHelpers.IsPathWithinBoundary(filePath, sensitiveDir))
             {
                 // Only allow read access to system directories unless explicitly allowed
                 if (accessType != FileAccessType.Read && !permissions.CustomPermissions.ContainsKey("allow_system_write"))

--- a/src/Andy.Tools/Library/Common/ToolHelpers.cs
+++ b/src/Andy.Tools/Library/Common/ToolHelpers.cs
@@ -27,6 +27,47 @@ public static class ToolHelpers
     public static readonly Encoding Utf8NoBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
 
     /// <summary>
+    /// The <see cref="StringComparison"/> to use when comparing filesystem paths on the current OS.
+    /// Windows and macOS default to case-insensitive filesystems; Linux is case-sensitive. Using the
+    /// OS-appropriate comparison avoids both over-permitting (treating distinct paths as equal on a
+    /// case-sensitive FS) and under-blocking on a case-insensitive FS.
+    /// </summary>
+    public static readonly StringComparison PathComparison =
+        OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+
+    /// <summary>
+    /// Determines whether <paramref name="candidatePath"/> is the same as, or contained within,
+    /// <paramref name="boundaryPath"/>, using a directory-separator-aware comparison.
+    /// <para>
+    /// A bare prefix test (<c>candidate.StartsWith(boundary)</c>) is unsafe: with a boundary of
+    /// <c>/home/user/app</c> a sibling path <c>/home/user/app-secrets/x</c> shares the textual prefix
+    /// yet is a different directory. This method requires either exact equality with the boundary or a
+    /// match up to and including a directory separator, closing that escape.
+    /// </para>
+    /// </summary>
+    /// <param name="candidatePath">The path to test. It is fully resolved before comparison.</param>
+    /// <param name="boundaryPath">The boundary directory. It is fully resolved before comparison.</param>
+    /// <returns><c>true</c> if the candidate is the boundary itself or lies beneath it.</returns>
+    public static bool IsPathWithinBoundary(string candidatePath, string boundaryPath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(candidatePath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(boundaryPath);
+
+        var candidate = Path.GetFullPath(candidatePath);
+        var boundary = Path.GetFullPath(boundaryPath)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+        if (candidate.Equals(boundary, PathComparison))
+        {
+            return true;
+        }
+
+        return candidate.StartsWith(boundary + Path.DirectorySeparatorChar, PathComparison);
+    }
+
+    /// <summary>
     /// Safely converts a path to an absolute path, ensuring it exists within allowed boundaries.
     /// </summary>
     /// <param name="path">The input path.</param>
@@ -57,8 +98,7 @@ public static class ToolHelpers
             // Security check: ensure the path doesn't escape the working directory if specified
             if (workingDirectory != null)
             {
-                var normalizedWorkingDir = Path.GetFullPath(workingDirectory);
-                if (!fullPath.StartsWith(normalizedWorkingDir, StringComparison.OrdinalIgnoreCase))
+                if (!IsPathWithinBoundary(fullPath, workingDirectory))
                 {
                     throw new ArgumentException($"Path '{path}' is outside the allowed working directory");
                 }
@@ -92,8 +132,7 @@ public static class ToolHelpers
 
             foreach (var allowedPath in permissions.AllowedPaths)
             {
-                var normalizedAllowedPath = Path.GetFullPath(allowedPath);
-                if (normalizedPath.StartsWith(normalizedAllowedPath, StringComparison.OrdinalIgnoreCase))
+                if (IsPathWithinBoundary(normalizedPath, allowedPath))
                 {
                     return true;
                 }

--- a/tests/Andy.Tools.Tests/Library/Common/ToolHelpersPathBoundaryTests.cs
+++ b/tests/Andy.Tools.Tests/Library/Common/ToolHelpersPathBoundaryTests.cs
@@ -1,0 +1,126 @@
+using Andy.Tools.Core;
+using Andy.Tools.Execution;
+using Andy.Tools.Library.Common;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace Andy.Tools.Tests.Library.Common;
+
+/// <summary>
+/// Regression tests for the path-confinement boundary check (issue #8). A bare
+/// <c>StartsWith</c> prefix test let a sibling directory sharing a textual prefix
+/// (e.g. <c>/app-secrets</c> vs <c>/app</c>) escape the boundary.
+/// </summary>
+public class ToolHelpersPathBoundaryTests
+{
+    // A unique, rooted, but non-existent tree. The checks are pure path-string logic
+    // after Path.GetFullPath, so the directories do not need to exist.
+    private static readonly string Root =
+        Path.Combine(Path.GetTempPath(), "andytools_pb_" + Guid.NewGuid().ToString("N"));
+    private static readonly string App = Path.Combine(Root, "app");
+    private static readonly string Sibling = Path.Combine(Root, "app-secrets");
+
+    [Fact]
+    public void IsPathWithinBoundary_FileBeneathBoundary_ReturnsTrue()
+    {
+        ToolHelpers.IsPathWithinBoundary(Path.Combine(App, "sub", "file.txt"), App)
+            .Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsPathWithinBoundary_BoundaryItself_ReturnsTrue()
+    {
+        ToolHelpers.IsPathWithinBoundary(App, App).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsPathWithinBoundary_SiblingSharingTextualPrefix_ReturnsFalse()
+    {
+        // "/<root>/app-secrets/x" starts with the string "/<root>/app" but is NOT inside it.
+        ToolHelpers.IsPathWithinBoundary(Path.Combine(Sibling, "secret.txt"), App)
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsPathWithinBoundary_TrailingSeparatorOnBoundary_IsHandled()
+    {
+        ToolHelpers.IsPathWithinBoundary(Path.Combine(App, "file.txt"), App + Path.DirectorySeparatorChar)
+            .Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsPathWithinBoundary_CaseVariant_MatchesOsCaseSensitivity()
+    {
+        var expected = ToolHelpers.PathComparison == StringComparison.OrdinalIgnoreCase;
+        ToolHelpers.IsPathWithinBoundary(Path.Combine(App.ToUpperInvariant(), "file.txt"), App)
+            .Should().Be(expected);
+    }
+
+    [Fact]
+    public void GetSafePath_SiblingPrefixEscape_Throws()
+    {
+        var escape = Path.Combine(Sibling, "secret.txt");
+        Action act = () => ToolHelpers.GetSafePath(escape, App);
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void GetSafePath_PathInsideWorkingDir_Succeeds()
+    {
+        var inside = Path.Combine(App, "ok.txt");
+        ToolHelpers.GetSafePath(inside, App).Should().Be(Path.GetFullPath(inside));
+    }
+
+    [Fact]
+    public void IsPathWithinAllowedPaths_SiblingPrefixEscape_ReturnsFalse()
+    {
+        var permissions = new ToolPermissions
+        {
+            FileSystemAccess = true,
+            AllowedPaths = new HashSet<string> { App }
+        };
+
+        ToolHelpers.IsPathWithinAllowedPaths(Path.Combine(App, "f.txt"), permissions)
+            .Should().BeTrue();
+        ToolHelpers.IsPathWithinAllowedPaths(Path.Combine(Sibling, "f.txt"), permissions)
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public void SecurityManager_AllowedPath_SiblingPrefixEscape_IsDenied()
+    {
+        var sm = new SecurityManager(new Mock<ILogger<SecurityManager>>().Object);
+        var permissions = new ToolPermissions
+        {
+            FileSystemAccess = true,
+            AllowedPaths = new HashSet<string> { App },
+            CustomPermissions = new Dictionary<string, object?>()
+        };
+
+        sm.IsFileAccessAllowed(Path.Combine(App, "f.txt"), permissions, FileAccessType.Read)
+            .Should().BeTrue();
+        sm.IsFileAccessAllowed(Path.Combine(Sibling, "f.txt"), permissions, FileAccessType.Read)
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public void SecurityManager_BlockedPath_SiblingPrefixIsNotOverBlocked()
+    {
+        var sm = new SecurityManager(new Mock<ILogger<SecurityManager>>().Object);
+        var blocked = Path.Combine(Root, "etc");
+        var permissions = new ToolPermissions
+        {
+            FileSystemAccess = true,
+            BlockedPaths = new HashSet<string> { blocked },
+            CustomPermissions = new Dictionary<string, object?>()
+        };
+
+        // Inside the blocked dir -> denied.
+        sm.IsFileAccessAllowed(Path.Combine(blocked, "passwd"), permissions, FileAccessType.Read)
+            .Should().BeFalse();
+        // Sibling sharing the "etc" prefix (e.g. "etc-notes") must NOT be over-blocked.
+        sm.IsFileAccessAllowed(Path.Combine(Root, "etc-notes", "x"), permissions, FileAccessType.Read)
+            .Should().BeTrue();
+    }
+}


### PR DESCRIPTION
Closes #8.

## Problem
Path-confinement checks used a raw `StartsWith` prefix test with no directory-separator boundary, and `OrdinalIgnoreCase` regardless of OS. Two escapes resulted:
- **Sibling-directory escape:** boundary `/home/user/app` admitted `/home/user/app-secrets/x` (shares the textual prefix).
- **Case mismatch:** on case-sensitive filesystems (Linux) distinct paths were treated as equal (over-permit), and the inverse under-blocks on case-insensitive FS.

## Fix
- New `ToolHelpers.IsPathWithinBoundary(candidate, boundary)`: resolves both paths and requires exact equality **or** a match up to and including a directory separator.
- New `ToolHelpers.PathComparison`: `OrdinalIgnoreCase` on Windows/macOS, `Ordinal` on Linux — matching default filesystem case sensitivity.
- Rewired `GetSafePath`, `IsPathWithinAllowedPaths`, and `SecurityManager` blocked/allowed/sensitive-directory checks to use it.

## Tests
`ToolHelpersPathBoundaryTests` (10 cases): sibling-prefix escape, boundary-itself, trailing separator, OS-aware case, `GetSafePath` escape, `IsPathWithinAllowedPaths`, and `SecurityManager` allow/block sibling cases. Full suite: **860 passing**.

> Part of the stacked review series. Base: `fix/utf8-bom-file-writes` (#35). Next: #9 (symlink resolution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)