### PR TITLE
fix(security): resolve symlinks before path confinement checks (#9)

### DIFF
--- a/src/Andy.Tools/Execution/SecurityManager.cs
+++ b/src/Andy.Tools/Execution/SecurityManager.cs
@@ -102,10 +102,12 @@ public class SecurityManager : ISecurityManager
             return false;
         }
 
-        // Normalize the path
+        // Normalize the path to its real (symlink-resolved) location. Path.GetFullPath alone does not
+        // resolve symbolic links, so a symlink inside an allowed directory pointing at a blocked/sensitive
+        // target would otherwise evade these checks.
         try
         {
-            filePath = Path.GetFullPath(filePath);
+            filePath = ToolHelpers.ResolveRealPath(filePath);
         }
         catch
         {
@@ -119,7 +121,7 @@ public class SecurityManager : ISecurityManager
             {
                 try
                 {
-                    var normalizedBlockedPath = Path.GetFullPath(blockedPath.Replace("~", Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)));
+                    var normalizedBlockedPath = ToolHelpers.ResolveRealPath(blockedPath.Replace("~", Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)));
                     return ToolHelpers.IsPathWithinBoundary(filePath, normalizedBlockedPath);
                 }
                 catch
@@ -141,7 +143,7 @@ public class SecurityManager : ISecurityManager
             {
                 try
                 {
-                    var normalizedAllowedPath = Path.GetFullPath(allowedPath.Replace("~", Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)));
+                    var normalizedAllowedPath = ToolHelpers.ResolveRealPath(allowedPath.Replace("~", Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)));
                     return ToolHelpers.IsPathWithinBoundary(filePath, normalizedAllowedPath);
                 }
                 catch
@@ -167,7 +169,7 @@ public class SecurityManager : ISecurityManager
 
         foreach (var sensitiveDir in sensitiveDirectories.Where(d => !string.IsNullOrEmpty(d)))
         {
-            if (ToolHelpers.IsPathWithinBoundary(filePath, sensitiveDir))
+            if (ToolHelpers.IsPathWithinBoundary(filePath, ToolHelpers.ResolveRealPath(sensitiveDir)))
             {
                 // Only allow read access to system directories unless explicitly allowed
                 if (accessType != FileAccessType.Read && !permissions.CustomPermissions.ContainsKey("allow_system_write"))

--- a/src/Andy.Tools/Library/Common/ToolHelpers.cs
+++ b/src/Andy.Tools/Library/Common/ToolHelpers.cs
@@ -68,6 +68,83 @@ public static class ToolHelpers
     }
 
     /// <summary>
+    /// Resolves a path to its real, symlink-free location so that confinement checks cannot be
+    /// bypassed by a symbolic link inside an allowed directory that points outside it.
+    /// <para>
+    /// <see cref="Path.GetFullPath(string)"/> collapses <c>..</c> segments but does <b>not</b> resolve
+    /// symbolic links. This walks the path component-by-component from the root, following any link
+    /// target (including intermediate symlinked directories). Components that do not exist yet (e.g. a
+    /// file about to be created) are resolved relative to their nearest existing, canonicalized ancestor.
+    /// </para>
+    /// </summary>
+    /// <param name="path">The path to resolve.</param>
+    /// <returns>The canonical absolute path. On any resolution error the best-effort full path is returned.</returns>
+    public static string ResolveRealPath(string path)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        return ResolveRealPathCore(Path.GetFullPath(path), depth: 0);
+    }
+
+    private static string ResolveRealPathCore(string full, int depth)
+    {
+        // Guard against symlink loops (ResolveLinkTarget also throws on cycles, but bound recursion too).
+        if (depth > 40)
+        {
+            return full;
+        }
+
+        try
+        {
+            var root = Path.GetPathRoot(full);
+            if (string.IsNullOrEmpty(root))
+            {
+                return full;
+            }
+
+            var parts = full[root.Length..].Split(
+                [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar],
+                StringSplitOptions.RemoveEmptyEntries);
+
+            var current = root;
+            for (var i = 0; i < parts.Length; i++)
+            {
+                current = Path.Combine(current, parts[i]);
+
+                // Only existing entries can be reparse points; non-existent tail segments are appended literally.
+                FileSystemInfo? info =
+                    Directory.Exists(current) ? new DirectoryInfo(current)
+                    : File.Exists(current) ? new FileInfo(current)
+                    : null;
+
+                var target = info?.ResolveLinkTarget(returnFinalTarget: true);
+                if (target == null)
+                {
+                    continue;
+                }
+
+                // The target may itself sit under symlinked ancestors, so canonicalize it fully, then
+                // resolve any remaining components relative to the canonical target.
+                var resolvedTarget = ResolveRealPathCore(Path.GetFullPath(target.FullName), depth + 1);
+                for (var j = i + 1; j < parts.Length; j++)
+                {
+                    resolvedTarget = Path.Combine(resolvedTarget, parts[j]);
+                }
+
+                return i + 1 < parts.Length
+                    ? ResolveRealPathCore(resolvedTarget, depth + 1)
+                    : resolvedTarget;
+            }
+
+            return current;
+        }
+        catch
+        {
+            // Symlink loops or permission errors: fall back to the non-resolved full path.
+            return full;
+        }
+    }
+
+    /// <summary>
     /// Safely converts a path to an absolute path, ensuring it exists within allowed boundaries.
     /// </summary>
     /// <param name="path">The input path.</param>
@@ -95,10 +172,13 @@ public static class ToolHelpers
             // Get the full path and normalize it
             var fullPath = Path.GetFullPath(path);
 
-            // Security check: ensure the path doesn't escape the working directory if specified
+            // Security check: ensure the path doesn't escape the working directory if specified.
+            // Compare the *real* (symlink-resolved) paths so a symlink inside the working directory
+            // that points outside it cannot be used to escape. The unresolved fullPath is still what
+            // callers receive, but it can only be returned once its real target is confirmed inside.
             if (workingDirectory != null)
             {
-                if (!IsPathWithinBoundary(fullPath, workingDirectory))
+                if (!IsPathWithinBoundary(ResolveRealPath(fullPath), ResolveRealPath(workingDirectory)))
                 {
                     throw new ArgumentException($"Path '{path}' is outside the allowed working directory");
                 }
@@ -128,11 +208,11 @@ public static class ToolHelpers
 
         try
         {
-            var normalizedPath = Path.GetFullPath(path);
+            var normalizedPath = ResolveRealPath(path);
 
             foreach (var allowedPath in permissions.AllowedPaths)
             {
-                if (IsPathWithinBoundary(normalizedPath, allowedPath))
+                if (IsPathWithinBoundary(normalizedPath, ResolveRealPath(allowedPath)))
                 {
                     return true;
                 }

--- a/src/Andy.Tools/Library/FileSystem/CopyFileTool.cs
+++ b/src/Andy.Tools/Library/FileSystem/CopyFileTool.cs
@@ -323,6 +323,14 @@ public partial class CopyFileTool : ToolBase
                 continue;
             }
 
+            // Honor follow_symlinks: when disabled (the default), do not traverse symbolic-link entries,
+            // which could point outside the source tree.
+            if (!followSymlinks && file.Attributes.HasFlag(FileAttributes.ReparsePoint))
+            {
+                stats.FilesSkipped++;
+                continue;
+            }
+
             try
             {
                 var destFile = Path.Combine(destinationPath, file.Name);

--- a/tests/Andy.Tools.Tests/Library/Common/ToolHelpersSymlinkTests.cs
+++ b/tests/Andy.Tools.Tests/Library/Common/ToolHelpersSymlinkTests.cs
@@ -1,0 +1,119 @@
+using Andy.Tools.Core;
+using Andy.Tools.Execution;
+using Andy.Tools.Library.Common;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace Andy.Tools.Tests.Library.Common;
+
+/// <summary>
+/// Regression tests for symlink resolution in confinement checks (issue #9). Path.GetFullPath does
+/// not resolve symbolic links, so a link inside an allowed directory pointing outside it could
+/// previously bypass the boundary.
+/// </summary>
+public sealed class ToolHelpersSymlinkTests : IDisposable
+{
+    private readonly string _root;
+    private readonly bool _symlinksSupported;
+
+    public ToolHelpersSymlinkTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "andytools_sym_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+        _symlinksSupported = TrySymlinkSupport();
+    }
+
+    private bool TrySymlinkSupport()
+    {
+        try
+        {
+            var target = Path.Combine(_root, "probe_target.txt");
+            File.WriteAllText(target, "x");
+            var link = Path.Combine(_root, "probe_link.txt");
+            File.CreateSymbolicLink(link, target);
+            return File.Exists(link);
+        }
+        catch
+        {
+            // Windows without privilege, or filesystem without symlink support.
+            return false;
+        }
+    }
+
+    [Fact]
+    public void ResolveRealPath_FollowsSymlinkToRealTarget()
+    {
+        if (!_symlinksSupported) { return; }
+
+        var outside = Path.Combine(_root, "outside");
+        Directory.CreateDirectory(outside);
+        var secret = Path.Combine(outside, "secret.txt");
+        File.WriteAllText(secret, "s");
+
+        var allowed = Path.Combine(_root, "allowed");
+        Directory.CreateDirectory(allowed);
+        var link = Path.Combine(allowed, "link.txt");
+        File.CreateSymbolicLink(link, secret);
+
+        ToolHelpers.ResolveRealPath(link)
+            .Should().Be(ToolHelpers.ResolveRealPath(secret));
+    }
+
+    [Fact]
+    public void SecurityManager_SymlinkInsideAllowedPointingOutside_IsDenied()
+    {
+        if (!_symlinksSupported) { return; }
+
+        var allowed = Path.Combine(_root, "allowed");
+        Directory.CreateDirectory(allowed);
+        var outside = Path.Combine(_root, "outside");
+        Directory.CreateDirectory(outside);
+        var secret = Path.Combine(outside, "secret.txt");
+        File.WriteAllText(secret, "s");
+
+        var link = Path.Combine(allowed, "escape.txt");
+        File.CreateSymbolicLink(link, secret);
+
+        var sm = new SecurityManager(new Mock<ILogger<SecurityManager>>().Object);
+        var permissions = new ToolPermissions
+        {
+            FileSystemAccess = true,
+            AllowedPaths = new HashSet<string> { allowed },
+            CustomPermissions = new Dictionary<string, object?>()
+        };
+
+        // The link lives inside the allowed dir, but its real target is outside -> denied.
+        sm.IsFileAccessAllowed(link, permissions, FileAccessType.Read)
+            .Should().BeFalse();
+
+        // A real file inside the allowed dir is still permitted.
+        var ok = Path.Combine(allowed, "ok.txt");
+        File.WriteAllText(ok, "ok");
+        sm.IsFileAccessAllowed(ok, permissions, FileAccessType.Read)
+            .Should().BeTrue();
+    }
+
+    [Fact]
+    public void GetSafePath_SymlinkEscapingWorkingDir_Throws()
+    {
+        if (!_symlinksSupported) { return; }
+
+        var work = Path.Combine(_root, "work");
+        Directory.CreateDirectory(work);
+        var outside = Path.Combine(_root, "out2");
+        Directory.CreateDirectory(outside);
+        var secret = Path.Combine(outside, "s.txt");
+        File.WriteAllText(secret, "s");
+        var link = Path.Combine(work, "escape.txt");
+        File.CreateSymbolicLink(link, secret);
+
+        Action act = () => ToolHelpers.GetSafePath(link, work);
+        act.Should().Throw<ArgumentException>();
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { /* best effort */ }
+    }
+}


### PR DESCRIPTION
Closes #9.

## Problem
`Path.GetFullPath` collapses `..` but does **not** resolve symbolic links, so a symlink inside an allowed directory pointing outside it bypassed the working-directory / allowed-paths / blocked / sensitive-path checks. `CopyFileTool.follow_symlinks` was declared but never used.

## Fix
- `ToolHelpers.ResolveRealPath`: resolves a path to its real, symlink-free location, walking component-by-component from the root and following link targets — including intermediate symlinked directories and symlinked ancestors of a target — with a recursion guard for cycles. Non-existent tail segments (e.g. a file about to be created) resolve against their nearest canonicalized ancestor.
- `GetSafePath`, `IsPathWithinAllowedPaths`, and `SecurityManager.IsFileAccessAllowed` now compare the **real** resolved paths. `GetSafePath` still returns the caller's path, but only after its real target is confirmed inside the boundary.
- `CopyFileTool` now honors `follow_symlinks`: when disabled (default), reparse-point entries are skipped during directory traversal.

## Tests
`ToolHelpersSymlinkTests`: real symlinks created in a temp tree (gracefully skipped where the OS/filesystem disallows symlink creation, e.g. unprivileged Windows). Verifies `ResolveRealPath` follows to the real target, `SecurityManager` denies a link-inside-allowed→outside while permitting a real file, and `GetSafePath` throws on a symlink escaping the working dir. Full suite: **863 passing**.

> Stacked on #8 (`fix/8-path-confinement`). Next: #10 (FS tools allowed-paths + catch-bypass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)