### PR TITLE
fix(security): enforce allowed-paths in FS tools and stop confinement bypass (#10)

### DIFF
--- a/src/Andy.Tools/Library/FileSystem/CopyFileTool.cs
+++ b/src/Andy.Tools/Library/FileSystem/CopyFileTool.cs
@@ -142,6 +142,17 @@ public partial class CopyFileTool : ToolBase
             var safeSourcePath = ToolHelpers.GetSafePath(sourcePath, context.WorkingDirectory);
             var safeDestinationPath = ToolHelpers.GetSafePath(destinationPath, context.WorkingDirectory);
 
+            // Enforce the caller's allowed-paths restriction on both endpoints.
+            if (!ToolHelpers.IsPathWithinAllowedPaths(safeSourcePath, context.Permissions))
+            {
+                return ToolResults.Failure($"Path '{safeSourcePath}' is not within allowed paths", "PATH_NOT_ALLOWED");
+            }
+
+            if (!ToolHelpers.IsPathWithinAllowedPaths(safeDestinationPath, context.Permissions))
+            {
+                return ToolResults.Failure($"Path '{safeDestinationPath}' is not within allowed paths", "PATH_NOT_ALLOWED");
+            }
+
             if (!File.Exists(safeSourcePath) && !Directory.Exists(safeSourcePath))
             {
                 return ToolResults.Failure(

--- a/src/Andy.Tools/Library/FileSystem/DeleteFileTool.cs
+++ b/src/Andy.Tools/Library/FileSystem/DeleteFileTool.cs
@@ -124,17 +124,15 @@ public class DeleteFileTool : ToolBase
                 return ToolResults.Failure("Target path is required", "MISSING_TARGET_PATH");
             }
             
-            // Resolve and validate the target path
-            string safeTargetPath;
-            try
+            // Resolve and validate the target path. GetSafePath enforces the working-directory
+            // boundary (it throws if the path escapes it); that exception is surfaced as a clean
+            // failure by the catch below rather than being swallowed and retried unconfined.
+            var safeTargetPath = ToolHelpers.GetSafePath(targetPath, context.WorkingDirectory);
+
+            // Enforce the caller's allowed-paths restriction before touching anything.
+            if (!ToolHelpers.IsPathWithinAllowedPaths(safeTargetPath, context.Permissions))
             {
-                safeTargetPath = ToolHelpers.GetSafePath(targetPath, context.WorkingDirectory);
-            }
-            catch (ArgumentException)
-            {
-                // If the path validation fails with working directory, try without it
-                // This handles cases where absolute paths are provided that are valid
-                safeTargetPath = ToolHelpers.GetSafePath(targetPath, null);
+                return ToolResults.Failure($"Path '{safeTargetPath}' is not within allowed paths", "PATH_NOT_ALLOWED");
             }
 
             if (!File.Exists(safeTargetPath) && !Directory.Exists(safeTargetPath))

--- a/src/Andy.Tools/Library/FileSystem/ListDirectoryTool.cs
+++ b/src/Andy.Tools/Library/FileSystem/ListDirectoryTool.cs
@@ -104,6 +104,12 @@ public partial class ListDirectoryTool : ToolBase
             // Resolve and validate the directory path
             var safePath = ToolHelpers.GetSafePath(directoryPath, context.WorkingDirectory);
 
+            // Enforce the caller's allowed-paths restriction before listing contents.
+            if (!ToolHelpers.IsPathWithinAllowedPaths(safePath, context.Permissions))
+            {
+                return ToolResults.Failure($"Path '{safePath}' is not within allowed paths", "PATH_NOT_ALLOWED");
+            }
+
             if (!Directory.Exists(safePath))
             {
                 return ToolResults.DirectoryNotFound(safePath);

--- a/src/Andy.Tools/Library/FileSystem/MoveFileTool.cs
+++ b/src/Andy.Tools/Library/FileSystem/MoveFileTool.cs
@@ -82,20 +82,21 @@ public partial class MoveFileTool : ToolBase
                 return ToolResults.Failure("destination_path cannot be empty", "MISSING_DESTINATION_PATH");
             }
             
-            // Resolve and validate paths
-            string safeSourcePath;
-            string safeDestinationPath;
-            try
+            // Resolve and validate paths. GetSafePath enforces the working-directory boundary (it throws
+            // if a path escapes it); that exception is surfaced as a clean failure by the catch below
+            // rather than being swallowed and retried unconfined.
+            var safeSourcePath = ToolHelpers.GetSafePath(sourcePath, context.WorkingDirectory);
+            var safeDestinationPath = ToolHelpers.GetSafePath(destinationPath, context.WorkingDirectory);
+
+            // Enforce the caller's allowed-paths restriction on both endpoints before moving anything.
+            if (!ToolHelpers.IsPathWithinAllowedPaths(safeSourcePath, context.Permissions))
             {
-                safeSourcePath = ToolHelpers.GetSafePath(sourcePath, context.WorkingDirectory);
-                safeDestinationPath = ToolHelpers.GetSafePath(destinationPath, context.WorkingDirectory);
+                return ToolResults.Failure($"Path '{safeSourcePath}' is not within allowed paths", "PATH_NOT_ALLOWED");
             }
-            catch (ArgumentException)
+
+            if (!ToolHelpers.IsPathWithinAllowedPaths(safeDestinationPath, context.Permissions))
             {
-                // If the path validation fails with working directory, try without it
-                // This handles cases where absolute paths are provided that are valid
-                safeSourcePath = ToolHelpers.GetSafePath(sourcePath, null);
-                safeDestinationPath = ToolHelpers.GetSafePath(destinationPath, null);
+                return ToolResults.Failure($"Path '{safeDestinationPath}' is not within allowed paths", "PATH_NOT_ALLOWED");
             }
 
             if (!File.Exists(safeSourcePath) && !Directory.Exists(safeSourcePath))

--- a/tests/Andy.Tools.Tests/Library/FileSystem/FileSystemAllowedPathsTests.cs
+++ b/tests/Andy.Tools.Tests/Library/FileSystem/FileSystemAllowedPathsTests.cs
@@ -1,0 +1,126 @@
+using Andy.Tools.Core;
+using Andy.Tools.Library.FileSystem;
+using FluentAssertions;
+
+namespace Andy.Tools.Tests.Library.FileSystem;
+
+/// <summary>
+/// Regression tests for issue #10: the destructive/disclosure file-system tools must enforce
+/// <c>permissions.AllowedPaths</c>, and Delete/Move must not silently bypass the working-directory
+/// boundary by catching the confinement error and retrying unconfined.
+/// </summary>
+public sealed class FileSystemAllowedPathsTests : IDisposable
+{
+    private readonly string _root;
+    private readonly string _allowed;
+    private readonly string _outside;
+
+    public FileSystemAllowedPathsTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "andytools_ap_" + Guid.NewGuid().ToString("N"));
+        _allowed = Path.Combine(_root, "allowed");
+        _outside = Path.Combine(_root, "outside");
+        Directory.CreateDirectory(_allowed);
+        Directory.CreateDirectory(_outside);
+    }
+
+    private static ToolExecutionContext ContextWithAllowed(string root, string allowed) => new()
+    {
+        WorkingDirectory = root,
+        Permissions = new ToolPermissions
+        {
+            FileSystemAccess = true,
+            AllowedPaths = new HashSet<string> { allowed }
+        }
+    };
+
+    [Fact]
+    public async Task Delete_OutsideAllowedPaths_IsRejected()
+    {
+        var victim = Path.Combine(_outside, "victim.txt");
+        await File.WriteAllTextAsync(victim, "secret");
+
+        var tool = new DeleteFileTool();
+        await tool.InitializeAsync();
+        var result = await tool.ExecuteAsync(
+            new Dictionary<string, object?> { ["target_path"] = victim },
+            ContextWithAllowed(_root, _allowed));
+
+        result.IsSuccessful.Should().BeFalse();
+        File.Exists(victim).Should().BeTrue("a delete outside AllowedPaths must not occur");
+    }
+
+    [Fact]
+    public async Task List_OutsideAllowedPaths_IsRejected()
+    {
+        var tool = new ListDirectoryTool();
+        await tool.InitializeAsync();
+        var result = await tool.ExecuteAsync(
+            new Dictionary<string, object?> { ["directory_path"] = _outside },
+            ContextWithAllowed(_root, _allowed));
+
+        result.IsSuccessful.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Copy_DestinationOutsideAllowedPaths_IsRejected()
+    {
+        var source = Path.Combine(_allowed, "src.txt");
+        await File.WriteAllTextAsync(source, "data");
+        var dest = Path.Combine(_outside, "copy.txt");
+
+        var tool = new CopyFileTool();
+        await tool.InitializeAsync();
+        var result = await tool.ExecuteAsync(
+            new Dictionary<string, object?> { ["source_path"] = source, ["destination_path"] = dest },
+            ContextWithAllowed(_root, _allowed));
+
+        result.IsSuccessful.Should().BeFalse();
+        File.Exists(dest).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Delete_EscapingWorkingDirectory_DoesNotSilentlySucceed()
+    {
+        // Working directory is _allowed; target escapes it via "..". Previously the tool caught the
+        // confinement error and retried with no working directory, deleting the file anyway.
+        var victim = Path.Combine(_outside, "escape.txt");
+        await File.WriteAllTextAsync(victim, "secret");
+        var escaping = Path.Combine("..", "outside", "escape.txt"); // relative escape from _allowed
+
+        var tool = new DeleteFileTool();
+        await tool.InitializeAsync();
+        var context = new ToolExecutionContext
+        {
+            WorkingDirectory = _allowed,
+            Permissions = new ToolPermissions { FileSystemAccess = true }
+        };
+        var result = await tool.ExecuteAsync(
+            new Dictionary<string, object?> { ["target_path"] = escaping },
+            context);
+
+        result.IsSuccessful.Should().BeFalse();
+        File.Exists(victim).Should().BeTrue("escaping the working directory must not delete the file");
+    }
+
+    [Fact]
+    public async Task Delete_InsideAllowedPaths_Succeeds()
+    {
+        var target = Path.Combine(_allowed, "ok.txt");
+        await File.WriteAllTextAsync(target, "x");
+
+        var tool = new DeleteFileTool();
+        await tool.InitializeAsync();
+        var result = await tool.ExecuteAsync(
+            new Dictionary<string, object?> { ["target_path"] = target },
+            ContextWithAllowed(_root, _allowed));
+
+        result.IsSuccessful.Should().BeTrue();
+        File.Exists(target).Should().BeFalse();
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { /* best effort */ }
+    }
+}

--- a/tests/Andy.Tools.Tests/Library/FileSystem/MoveFileToolTests.cs
+++ b/tests/Andy.Tools.Tests/Library/FileSystem/MoveFileToolTests.cs
@@ -390,7 +390,7 @@ public class MoveFileToolTests : IDisposable
         const string content = "Cross-volume content";
         await File.WriteAllTextAsync(_sourceFile, content);
 
-        // For testing purposes, we'll simulate a cross-volume move by using a different temp directory
+        // For testing purposes, we'll simulate a cross-volume move by using a different temp directory.
         var crossVolumeDestination = Path.Combine(Path.GetTempPath(), "CrossVolumeTest", "destination.txt");
         Directory.CreateDirectory(Path.GetDirectoryName(crossVolumeDestination)!);
 
@@ -400,7 +400,10 @@ public class MoveFileToolTests : IDisposable
             ["destination_path"] = crossVolumeDestination
         };
 
-        var context = new ToolExecutionContext { WorkingDirectory = _testDirectory };
+        // Both endpoints live under the system temp root. Use it as the working directory so the move
+        // stays within the confinement boundary (the destination is in a sibling temp folder, not under
+        // _testDirectory). This exercises cross-directory move handling without relying on a path escape.
+        var context = new ToolExecutionContext { WorkingDirectory = Path.GetTempPath() };
 
         // Initialize the tool
         await _tool.InitializeAsync();


### PR DESCRIPTION
Closes #10.

## Problem
- `DeleteFileTool`, `CopyFileTool`, `MoveFileTool`, `ListDirectoryTool` never enforced `permissions.AllowedPaths` (only Read/Write did) — a caller with a restricted allow-list could still delete/move/list/copy anywhere.
- `DeleteFileTool`/`MoveFileTool` caught the working-directory confinement `ArgumentException` from `GetSafePath` and retried with `null` working directory, converting a boundary violation into a successful **unconfined** operation.

## Fix
- All four tools now call `ToolHelpers.IsPathWithinAllowedPaths` and return `PATH_NOT_ALLOWED` for paths outside the allow-list (both source and destination for copy/move), mirroring the existing Read/Write pattern.
- Removed the catch-and-retry-unconfined fallback; the confinement exception now surfaces as a clean failure via the tools' existing catch.

## Tests
`FileSystemAllowedPathsTests`: delete/list/copy outside `AllowedPaths` are rejected (and the file is untouched); a relative `..` escape from the working directory no longer silently succeeds; a delete inside the allow-list still works. Also corrected the cross-volume move test, which previously relied on the removed escape, to keep both endpoints within the boundary. Full suite: **868 passing**.

> Stacked on #9 (`fix/9-symlink-resolution`). Completes the path-confinement cluster (#8–#11 minus the profile fix). Next: #11 (profile-name path traversal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)