### PR TITLE
fix(security): block SSRF to internal addresses in HttpRequestTool (#12)

### DIFF
--- a/src/Andy.Tools/Execution/SecurityManager.cs
+++ b/src/Andy.Tools/Execution/SecurityManager.cs
@@ -231,8 +231,21 @@ public class SecurityManager : ISecurityManager
             return allowed;
         }
 
-        // Block private IP ranges unless explicitly allowed
-        return !IsPrivateIpAddress(host) || permissions.CustomPermissions.ContainsKey("allow_private_networks");
+        // Block private/internal IP ranges unless explicitly allowed.
+        if (!IsPrivateIpAddress(host))
+        {
+            return true;
+        }
+
+        if (permissions.CustomPermissions.ContainsKey("allow_private_networks"))
+        {
+            return true;
+        }
+
+        // The narrower allow_localhost permission unlocks loopback addresses only.
+        return permissions.CustomPermissions.ContainsKey("allow_localhost")
+            && System.Net.IPAddress.TryParse(host, out var ip)
+            && System.Net.IPAddress.IsLoopback(ip);
     }
 
     /// <inheritdoc />
@@ -321,30 +334,8 @@ public class SecurityManager : ISecurityManager
             return false;
         }
 
-        var bytes = ipAddress.GetAddressBytes();
-
-        // IPv4 private ranges
-        if (bytes.Length == 4)
-        {
-            // 10.0.0.0/8
-            if (bytes[0] == 10)
-            {
-                return true;
-            }
-
-            // 172.16.0.0/12
-            if (bytes[0] == 172 && bytes[1] >= 16 && bytes[1] <= 31)
-            {
-                return true;
-            }
-
-            // 192.168.0.0/16
-            if (bytes[0] == 192 && bytes[1] == 168)
-            {
-                return true;
-            }
-        }
-
-        return false;
+        // Delegate to the shared classifier, which covers loopback, link-local, ULA, CGNAT, private,
+        // multicast and unspecified ranges for both IPv4 and IPv6.
+        return ToolHelpers.IsPrivateOrLocalAddress(ipAddress);
     }
 }

--- a/src/Andy.Tools/Library/Common/ToolHelpers.cs
+++ b/src/Andy.Tools/Library/Common/ToolHelpers.cs
@@ -476,6 +476,97 @@ public static class ToolHelpers
     }
 
     /// <summary>
+    /// Determines whether an IP address targets the loopback, link-local, unique-local, carrier-grade-NAT,
+    /// private, multicast, or unspecified ranges — i.e. an internal/non-public address that should be
+    /// blocked by default to prevent Server-Side Request Forgery (SSRF).
+    /// </summary>
+    /// <param name="address">The address to classify.</param>
+    /// <returns><c>true</c> if the address is internal/non-routable on the public internet.</returns>
+    public static bool IsPrivateOrLocalAddress(SystemNet.IPAddress address)
+    {
+        ArgumentNullException.ThrowIfNull(address);
+
+        if (address.IsIPv4MappedToIPv6)
+        {
+            address = address.MapToIPv4();
+        }
+
+        if (SystemNet.IPAddress.IsLoopback(address))
+        {
+            return true; // 127.0.0.0/8 and ::1
+        }
+
+        var b = address.GetAddressBytes();
+
+        if (address.AddressFamily == SystemNet.Sockets.AddressFamily.InterNetwork)
+        {
+            return b[0] switch
+            {
+                0 => true,                                   // 0.0.0.0/8 (this network / unspecified)
+                10 => true,                                  // 10.0.0.0/8
+                127 => true,                                 // loopback (also caught above)
+                169 when b[1] == 254 => true,                // link-local 169.254.0.0/16
+                172 when b[1] >= 16 && b[1] <= 31 => true,   // 172.16.0.0/12
+                192 when b[1] == 168 => true,                // 192.168.0.0/16
+                100 when b[1] >= 64 && b[1] <= 127 => true,  // CGNAT 100.64.0.0/10
+                >= 224 => true,                              // multicast 224/4 and reserved 240/4
+                _ => false
+            };
+        }
+
+        if (address.AddressFamily == SystemNet.Sockets.AddressFamily.InterNetworkV6)
+        {
+            if (address.IsIPv6LinkLocal || address.IsIPv6SiteLocal || address.IsIPv6Multicast
+                || address.Equals(SystemNet.IPAddress.IPv6Any))
+            {
+                return true;
+            }
+
+            // Unique Local Address fc00::/7.
+            return (b[0] & 0xFE) == 0xFC;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Determines whether a host (IP literal or DNS name) resolves to an internal/non-public address and
+    /// should therefore be blocked by default for outbound requests (SSRF protection). DNS names are
+    /// resolved; a host is treated as blocked if <b>any</b> resolved address is internal (defends against
+    /// DNS-rebinding split answers). On a resolution failure this returns <c>false</c> so the request
+    /// fails naturally at connect time, where the actual endpoint IP is the authoritative check.
+    /// </summary>
+    public static async Task<bool> IsBlockedInternalHostAsync(string host, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(host))
+        {
+            return true;
+        }
+
+        host = host.Trim('[', ']'); // strip IPv6 literal brackets
+
+        if (SystemNet.IPAddress.TryParse(host, out var literal))
+        {
+            return IsPrivateOrLocalAddress(literal);
+        }
+
+        if (string.Equals(host, "localhost", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        try
+        {
+            var addresses = await SystemNet.Dns.GetHostAddressesAsync(host, cancellationToken);
+            return addresses.Length > 0 && addresses.Any(IsPrivateOrLocalAddress);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
     /// Measures execution time of an operation.
     /// </summary>
     /// <typeparam name="T">The return type.</typeparam>

--- a/src/Andy.Tools/Library/Web/HttpRequestTool.cs
+++ b/src/Andy.Tools/Library/Web/HttpRequestTool.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Net.Sockets;
 using System.Text;
 using System.Text.Json;
 using Andy.Tools.Core;
@@ -140,23 +141,66 @@ public class HttpRequestTool : ToolBase
 
             ReportProgress(context, "Preparing HTTP request...", 10);
 
+            // SSRF protection: by default, block requests whose target resolves to an internal/non-public
+            // address (loopback, link-local, ULA, CGNAT, private, multicast). Callers may opt in to
+            // internal targets via the allow_private_networks / allow_localhost custom permissions.
+            var allowInternal = context.Permissions.CustomPermissions.ContainsKey("allow_private_networks")
+                || context.Permissions.CustomPermissions.ContainsKey("allow_localhost");
+
+            if (!allowInternal)
+            {
+                var requestHost = new Uri(url).Host;
+                if (await ToolHelpers.IsBlockedInternalHostAsync(requestHost, context.CancellationToken))
+                {
+                    return ToolResults.Failure(
+                        $"Request to '{requestHost}' is blocked: it resolves to an internal/non-public address (SSRF protection). Grant the 'allow_private_networks' permission to override.",
+                        "BLOCKED_INTERNAL_HOST");
+                }
+            }
+
             // Parse headers
             var headers = ParseHeaders(headersObj);
 
-            // Create HTTP client with custom settings
-            using var handler = new HttpClientHandler()
+            // Create HTTP client with custom settings. SocketsHttpHandler lets us validate the *actual*
+            // address being connected to on every connection — including redirect targets and late DNS
+            // resolution — which closes redirect-based and DNS-rebinding SSRF bypasses.
+            using var handler = new SocketsHttpHandler
             {
-                UseCookies = false
-            };
+                UseCookies = false,
+                AllowAutoRedirect = followRedirects,
+                ConnectCallback = async (ctx, ct) =>
+                {
+                    var targetHost = ctx.DnsEndPoint.Host;
+                    var addresses = IPAddress.TryParse(targetHost, out var literal)
+                        ? [literal]
+                        : await Dns.GetHostAddressesAsync(targetHost, ct);
 
-            if (!followRedirects)
-            {
-                handler.AllowAutoRedirect = false;
-            }
+                    if (!allowInternal && addresses.Any(ToolHelpers.IsPrivateOrLocalAddress))
+                    {
+                        throw new HttpRequestException(
+                            $"Blocked connection to internal address for host '{targetHost}' (SSRF protection).");
+                    }
+
+                    var socket = new Socket(SocketType.Stream, ProtocolType.Tcp)
+                    {
+                        NoDelay = true
+                    };
+                    try
+                    {
+                        await socket.ConnectAsync(addresses, ctx.DnsEndPoint.Port, ct);
+                        return new NetworkStream(socket, ownsSocket: true);
+                    }
+                    catch
+                    {
+                        socket.Dispose();
+                        throw;
+                    }
+                }
+            };
 
             if (!validateSsl)
             {
-                handler.ServerCertificateCustomValidationCallback = (sender, cert, chain, sslPolicyErrors) => true;
+                handler.SslOptions.RemoteCertificateValidationCallback = (sender, cert, chain, sslPolicyErrors) => true;
             }
 
             using var httpClient = new HttpClient(handler)

--- a/tests/Andy.Tools.Tests/Library/Web/HttpRequestSsrfTests.cs
+++ b/tests/Andy.Tools.Tests/Library/Web/HttpRequestSsrfTests.cs
@@ -1,0 +1,71 @@
+using System.Net;
+using Andy.Tools.Core;
+using Andy.Tools.Execution;
+using Andy.Tools.Library.Common;
+using Andy.Tools.Library.Web;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace Andy.Tools.Tests.Library.Web;
+
+/// <summary>
+/// Regression tests for issue #12: SSRF protection in the HTTP tool and network classification.
+/// </summary>
+public class HttpRequestSsrfTests
+{
+    [Theory]
+    [InlineData("127.0.0.1", true)]
+    [InlineData("127.5.5.5", true)]
+    [InlineData("::1", true)]
+    [InlineData("10.0.0.1", true)]
+    [InlineData("172.16.0.1", true)]
+    [InlineData("172.31.255.255", true)]
+    [InlineData("192.168.1.1", true)]
+    [InlineData("169.254.169.254", true)] // cloud metadata endpoint
+    [InlineData("100.64.0.1", true)]       // CGNAT
+    [InlineData("0.0.0.0", true)]
+    [InlineData("224.0.0.1", true)]        // multicast
+    [InlineData("fc00::1", true)]          // unique local
+    [InlineData("fe80::1", true)]          // link-local
+    [InlineData("8.8.8.8", false)]
+    [InlineData("1.1.1.1", false)]
+    [InlineData("172.32.0.1", false)]      // just outside 172.16/12
+    public void IsPrivateOrLocalAddress_ClassifiesRanges(string ip, bool expectedInternal)
+    {
+        ToolHelpers.IsPrivateOrLocalAddress(IPAddress.Parse(ip)).Should().Be(expectedInternal);
+    }
+
+    [Theory]
+    [InlineData("http://127.0.0.1:1/")]
+    [InlineData("http://localhost:1/")]
+    [InlineData("http://169.254.169.254/latest/meta-data/")]
+    [InlineData("http://[::1]:1/")]
+    public async Task HttpRequest_ToInternalHost_IsBlockedByDefault(string url)
+    {
+        var tool = new HttpRequestTool();
+        await tool.InitializeAsync();
+
+        var result = await tool.ExecuteAsync(
+            new Dictionary<string, object?> { ["url"] = url },
+            new ToolExecutionContext());
+
+        result.IsSuccessful.Should().BeFalse();
+        // Error surfaced from the preflight check.
+        (result.ErrorMessage ?? string.Empty).Should().Contain("SSRF");
+    }
+
+    [Fact]
+    public void SecurityManager_PrivateIp_NetworkAccessDenied()
+    {
+        var sm = new SecurityManager(new Mock<ILogger<SecurityManager>>().Object);
+        var permissions = new ToolPermissions
+        {
+            NetworkAccess = true,
+            CustomPermissions = new Dictionary<string, object?>()
+        };
+
+        sm.IsNetworkAccessAllowed("169.254.169.254", permissions).Should().BeFalse();
+        sm.IsNetworkAccessAllowed("10.1.2.3", permissions).Should().BeFalse();
+    }
+}


### PR DESCRIPTION
Closes #12.

## Problem
`HttpRequestTool` validated only the URL scheme — it could reach loopback, link-local (`169.254.169.254` metadata), and RFC1918 addresses, and `follow_redirects` (default on) could 30x to them. `SecurityManager.IsPrivateIpAddress` covered only IPv4 `10/172.16/192.168`.

## Fix
- `ToolHelpers.IsPrivateOrLocalAddress`: classifies loopback, link-local, ULA, CGNAT, private, multicast and unspecified ranges (IPv4 + IPv6, incl. IPv4-mapped).
- `ToolHelpers.IsBlockedInternalHostAsync`: resolves DNS names and blocks if **any** resolved address is internal (defends against rebinding split answers).
- `HttpRequestTool`: a preflight host check **plus** a `SocketsHttpHandler.ConnectCallback` that validates the *actual* connected IP on every connection — including redirect targets and connect-time DNS resolution — closing redirect/rebinding bypasses. Callers opt in to internal targets via `allow_private_networks` / `allow_localhost`.
- `SecurityManager.IsPrivateIpAddress` now delegates to the shared classifier; loopback remains unlockable by the narrower `allow_localhost` permission (existing behavior preserved).

## Tests
`HttpRequestSsrfTests`: range-classification table (loopback/link-local/ULA/CGNAT/multicast/private vs public), HTTP requests to internal hosts blocked by default (no network needed — rejected at preflight), and `SecurityManager` denying private IPs. Full suite: **897 passing**.

> Stacked on #11. `HttpRequestTool` is reworked further by #24 (handler reuse + streaming), which builds on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)