### PR TITLE
fix(security): bound user regex with a match timeout and fix glob translation (#14)

### DIFF
--- a/src/Andy.Tools/Discovery/ToolDiscoveryService.cs
+++ b/src/Andy.Tools/Discovery/ToolDiscoveryService.cs
@@ -1,6 +1,6 @@
 using System.Reflection;
-using System.Text.RegularExpressions;
 using Andy.Tools.Core;
+using Andy.Tools.Library.Common;
 using Andy.Tools.Validation;
 using Microsoft.Extensions.Logging;
 
@@ -367,12 +367,7 @@ public class ToolDiscoveryService(IToolValidator validator, ILogger<ToolDiscover
     {
         var assemblyName = assembly.GetName().Name;
         return string.IsNullOrEmpty(assemblyName)
-            ? true
-            : excludePatterns.Any(pattern =>
-        {
-            var regex = new Regex(pattern.Replace("*", ".*"), RegexOptions.IgnoreCase);
-            return regex.IsMatch(assemblyName);
-        });
+            || excludePatterns.Any(pattern => ToolHelpers.IsGlobMatch(assemblyName, pattern));
     }
 
     private static IList<string> GetAvailablePluginDirectories()

--- a/src/Andy.Tools/Library/Common/ToolHelpers.cs
+++ b/src/Andy.Tools/Library/Common/ToolHelpers.cs
@@ -476,6 +476,29 @@ public static class ToolHelpers
     }
 
     /// <summary>
+    /// Matches a name against a shell-style glob containing <c>*</c> (any run) and <c>?</c> (any single
+    /// char). All other characters are treated literally — unlike a naive <c>pattern.Replace("*", ".*")</c>,
+    /// which leaves regex metacharacters (e.g. <c>.</c>, <c>(</c>, <c>[</c>) active and can either match
+    /// too much or throw on an invalid pattern. The match is anchored and bounded by a short timeout.
+    /// </summary>
+    /// <param name="name">The candidate name.</param>
+    /// <param name="pattern">The glob pattern.</param>
+    /// <param name="ignoreCase">Whether matching is case-insensitive (default true).</param>
+    public static bool IsGlobMatch(string name, string pattern, bool ignoreCase = true)
+    {
+        var regexPattern = "^" + Regex.Escape(pattern).Replace("\\*", ".*").Replace("\\?", ".") + "$";
+        var options = ignoreCase ? RegexOptions.IgnoreCase : RegexOptions.None;
+        try
+        {
+            return Regex.IsMatch(name, regexPattern, options, TimeSpan.FromSeconds(1));
+        }
+        catch (RegexMatchTimeoutException)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
     /// Determines whether an IP address targets the loopback, link-local, unique-local, carrier-grade-NAT,
     /// private, multicast, or unspecified ranges — i.e. an internal/non-public address that should be
     /// blocked by default to prevent Server-Side Request Forgery (SSRF).

--- a/src/Andy.Tools/Library/FileSystem/CopyFileTool.cs
+++ b/src/Andy.Tools/Library/FileSystem/CopyFileTool.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Text.RegularExpressions;
 using Andy.Tools.Core;
 using Andy.Tools.Library.Common;
 
@@ -396,16 +395,9 @@ public partial class CopyFileTool : ToolBase
     private static bool ShouldExclude(string name, List<string> excludePatterns)
     {
         return excludePatterns.Any(pattern =>
-        {
-            // Simple wildcard matching
-            if (pattern.Contains('*'))
-            {
-                var regexPattern = "^" + pattern.Replace("*", ".*") + "$";
-                return Regex.IsMatch(name, regexPattern, RegexOptions.IgnoreCase);
-            }
-
-            return string.Equals(name, pattern, StringComparison.OrdinalIgnoreCase);
-        });
+            pattern.Contains('*') || pattern.Contains('?')
+                ? ToolHelpers.IsGlobMatch(name, pattern)
+                : string.Equals(name, pattern, StringComparison.OrdinalIgnoreCase));
     }
 
     private static int CountFiles(DirectoryInfo directory, bool recursive, List<string> excludePatterns)

--- a/src/Andy.Tools/Library/FileSystem/DeleteFileTool.cs
+++ b/src/Andy.Tools/Library/FileSystem/DeleteFileTool.cs
@@ -1,4 +1,3 @@
-using System.Text.RegularExpressions;
 using Andy.Tools.Core;
 using Andy.Tools.Library.Common;
 
@@ -456,15 +455,9 @@ public class DeleteFileTool : ToolBase
     private static bool ShouldExclude(string name, List<string> excludePatterns)
     {
         return excludePatterns.Any(pattern =>
-        {
-            if (pattern.Contains('*'))
-            {
-                var regexPattern = "^" + pattern.Replace("*", ".*") + "$";
-                return Regex.IsMatch(name, regexPattern, RegexOptions.IgnoreCase);
-            }
-
-            return string.Equals(name, pattern, StringComparison.OrdinalIgnoreCase);
-        });
+            pattern.Contains('*') || pattern.Contains('?')
+                ? ToolHelpers.IsGlobMatch(name, pattern)
+                : string.Equals(name, pattern, StringComparison.OrdinalIgnoreCase));
     }
 
     private static void CopyDirectory(string sourceDir, string destinationDir)

--- a/src/Andy.Tools/Library/Text/ReplaceTextTool.cs
+++ b/src/Andy.Tools/Library/Text/ReplaceTextTool.cs
@@ -235,8 +235,13 @@ public class ReplaceTextTool : ToolBase
         }
     }
 
+    // Bounds the time spent on any single match to prevent catastrophic-backtracking (ReDoS) from a
+    // user-supplied pattern. A match exceeding this throws RegexMatchTimeoutException.
+    private static readonly TimeSpan RegexMatchTimeout = TimeSpan.FromSeconds(2);
+
     private static Regex CreateSearchRegex(string pattern, string searchType, bool caseSensitive, bool wholeWordsOnly)
     {
+        var isUserRegex = searchType.Equals("regex", StringComparison.OrdinalIgnoreCase);
         var regexPattern = searchType.ToLowerInvariant() switch
         {
             "regex" => pattern,
@@ -251,13 +256,14 @@ public class ReplaceTextTool : ToolBase
             regexPattern = @"\b" + regexPattern + @"\b";
         }
 
-        var options = RegexOptions.Compiled;
+        // Do not JIT-compile an arbitrary user-supplied pattern; only our own escaped patterns.
+        var options = isUserRegex ? RegexOptions.None : RegexOptions.Compiled;
         if (!caseSensitive)
         {
             options |= RegexOptions.IgnoreCase;
         }
 
-        return new Regex(regexPattern, options);
+        return new Regex(regexPattern, options, RegexMatchTimeout);
     }
 
     private static async Task ProcessFileAsync(

--- a/src/Andy.Tools/Library/Text/SearchTextTool.cs
+++ b/src/Andy.Tools/Library/Text/SearchTextTool.cs
@@ -207,8 +207,14 @@ public class SearchTextTool : ToolBase
         }
     }
 
+    // Bounds the time spent on any single match to prevent catastrophic-backtracking (ReDoS) from a
+    // user-supplied pattern. A match exceeding this throws RegexMatchTimeoutException, surfaced as a
+    // clean failure rather than hanging the process.
+    private static readonly TimeSpan RegexMatchTimeout = TimeSpan.FromSeconds(2);
+
     private static Regex CreateSearchRegex(string pattern, string searchType, bool caseSensitive, bool wholeWordsOnly)
     {
+        var isUserRegex = searchType.Equals("regex", StringComparison.OrdinalIgnoreCase);
         var regexPattern = searchType.ToLowerInvariant() switch
         {
             "regex" => pattern,
@@ -223,13 +229,14 @@ public class SearchTextTool : ToolBase
             regexPattern = @"\b" + regexPattern + @"\b";
         }
 
-        var options = RegexOptions.Compiled;
+        // Do not JIT-compile an arbitrary user-supplied pattern; only our own escaped patterns.
+        var options = isUserRegex ? RegexOptions.None : RegexOptions.Compiled;
         if (!caseSensitive)
         {
             options |= RegexOptions.IgnoreCase;
         }
 
-        return new Regex(regexPattern, options);
+        return new Regex(regexPattern, options, RegexMatchTimeout);
     }
 
     private static async Task SearchFileAsync(

--- a/tests/Andy.Tools.Tests/Library/Common/GlobAndRegexSafetyTests.cs
+++ b/tests/Andy.Tools.Tests/Library/Common/GlobAndRegexSafetyTests.cs
@@ -1,0 +1,59 @@
+using System.Diagnostics;
+using Andy.Tools.Core;
+using Andy.Tools.Library.Common;
+using Andy.Tools.Library.Text;
+using FluentAssertions;
+
+namespace Andy.Tools.Tests.Library.Common;
+
+/// <summary>
+/// Regression tests for issue #14: user regexes ran with no timeout (ReDoS) and glob-to-regex
+/// translation left metacharacters active (`.` matched any char; invalid patterns threw).
+/// </summary>
+public class GlobAndRegexSafetyTests
+{
+    [Theory]
+    [InlineData("file.log", "file.log", true)]
+    [InlineData("fileXlog", "file.log", false)] // literal dot must NOT match any char
+    [InlineData("notes.txt", "*.txt", true)]
+    [InlineData("notes.md", "*.txt", false)]
+    [InlineData("a1c", "a?c", true)]
+    [InlineData("ac", "a?c", false)]
+    public void IsGlobMatch_TreatsNonWildcardsLiterally(string name, string pattern, bool expected)
+    {
+        ToolHelpers.IsGlobMatch(name, pattern).Should().Be(expected);
+    }
+
+    [Fact]
+    public void IsGlobMatch_RegexMetacharacterPattern_DoesNotThrow()
+    {
+        // A pattern with regex metacharacters used to throw RegexParseException; now it is matched literally.
+        Action act = () => ToolHelpers.IsGlobMatch("a(b[c", "a(b[c");
+        act.Should().NotThrow();
+        ToolHelpers.IsGlobMatch("a(b[c", "a(b[c").Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task SearchText_CatastrophicRegex_TimesOutInsteadOfHanging()
+    {
+        var tool = new SearchTextTool();
+        await tool.InitializeAsync();
+
+        // Classic catastrophic-backtracking pattern against a non-matching input.
+        var parameters = new Dictionary<string, object?>
+        {
+            ["text"] = new string('a', 40) + "!",
+            ["search_pattern"] = "(a+)+$",
+            ["search_type"] = "regex"
+        };
+
+        var sw = Stopwatch.StartNew();
+        var result = await tool.ExecuteAsync(parameters, new ToolExecutionContext());
+        sw.Stop();
+
+        // Must not hang: a 2s match timeout bounds it (well under this generous ceiling).
+        sw.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(15));
+        // Either it completed quickly with no match, or it surfaced a clean failure — never a hang.
+        result.Should().NotBeNull();
+    }
+}


### PR DESCRIPTION
Closes #14.

## Problem
- `SearchTextTool`/`ReplaceTextTool` compiled a raw user pattern (`search_type=regex`) with `RegexOptions.Compiled` and **no** match timeout — a catastrophic-backtracking pattern (`(a+)+$`) could pin a CPU (ReDoS).
- Glob exclusions used `pattern.Replace("*", ".*")` with no escaping, so a literal `.` matched any char and regex metacharacters could throw `RegexParseException`, aborting the whole delete/copy/discovery.

## Fix
- Both text tools: regexes now carry a **2s match timeout**; arbitrary user patterns are no longer JIT-compiled (only our own escaped patterns are).
- New `ToolHelpers.IsGlobMatch`: `Regex.Escape` then map `*`→`.*`, `?`→`.`, anchored, with a 1s timeout. Used by `DeleteFileTool`/`CopyFileTool` exclusions and `ToolDiscoveryService` assembly exclusion.

## Tests
`GlobAndRegexSafetyTests`: literal `.`/`?` semantics, metacharacter patterns don't throw, and a catastrophic regex completes/fails fast instead of hanging. Full suite: **909 passing**.

> Stacked on #13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)