### PR TITLE
fix(security): honor MaxDirectoryDepth and add a plugin-assembly vetting hook (#15)

### DIFF
--- a/src/Andy.Tools/Discovery/ToolDiscoveryOptions.cs
+++ b/src/Andy.Tools/Discovery/ToolDiscoveryOptions.cs
@@ -72,4 +72,14 @@ public class ToolDiscoveryOptions
     /// Gets or sets whether to load assemblies with reflection-only context.
     /// </summary>
     public bool UseReflectionOnlyLoad { get; set; } = false;
+
+    /// <summary>
+    /// Optional predicate used to vet a plugin assembly file before it is loaded from disk. Loading an
+    /// assembly executes its module initializers and exposes its code, so dropping an untrusted DLL into
+    /// a scanned directory is arbitrary code execution. When set, only files for which this returns
+    /// <c>true</c> are loaded; the rest are skipped and logged. Use it to enforce a strong-name /
+    /// Authenticode / hash allowlist. When <c>null</c> (default) all matching files are loaded (legacy
+    /// behavior) — only point <see cref="PluginDirectories"/> at trusted, write-protected locations.
+    /// </summary>
+    public Func<string, bool>? PluginAssemblyValidator { get; set; }
 }

--- a/src/Andy.Tools/Discovery/ToolDiscoveryService.cs
+++ b/src/Andy.Tools/Discovery/ToolDiscoveryService.cs
@@ -108,10 +108,11 @@ public class ToolDiscoveryService(IToolValidator validator, ILogger<ToolDiscover
 
                 try
                 {
-                    var directoryTools = await DiscoverToolsFromDirectoryAsync(
+                    var directoryTools = await DiscoverToolsFromDirectoryCoreAsync(
                         directory,
                         options.PluginFilePatterns,
-                        options.MaxDirectoryDepth > 1,
+                        Math.Max(1, options.MaxDirectoryDepth),
+                        options.PluginAssemblyValidator,
                         cancellationToken);
                     discoveredTools.AddRange(directoryTools);
 
@@ -255,9 +256,25 @@ public class ToolDiscoveryService(IToolValidator validator, ILogger<ToolDiscover
     }
 
     /// <inheritdoc />
-    public async Task<IReadOnlyList<DiscoveredTool>> DiscoverToolsFromDirectoryAsync(string directoryPath, IList<string>? filePatterns = null, bool recursive = true, CancellationToken cancellationToken = default)
+    public Task<IReadOnlyList<DiscoveredTool>> DiscoverToolsFromDirectoryAsync(string directoryPath, IList<string>? filePatterns = null, bool recursive = true, CancellationToken cancellationToken = default)
     {
-        filePatterns ??= ["*.dll"];
+        // recursive==true preserves the documented "scan all subdirectories" behavior for direct callers;
+        // the options-driven path uses an explicit depth instead (see DiscoverToolsAsync).
+        return DiscoverToolsFromDirectoryCoreAsync(
+            directoryPath,
+            filePatterns ?? ["*.dll"],
+            recursive ? int.MaxValue : 1,
+            assemblyValidator: null,
+            cancellationToken);
+    }
+
+    private async Task<IReadOnlyList<DiscoveredTool>> DiscoverToolsFromDirectoryCoreAsync(
+        string directoryPath,
+        IList<string> filePatterns,
+        int maxDepth,
+        Func<string, bool>? assemblyValidator,
+        CancellationToken cancellationToken)
+    {
         var discoveredTools = new List<DiscoveredTool>();
 
         if (!Directory.Exists(directoryPath))
@@ -268,11 +285,7 @@ public class ToolDiscoveryService(IToolValidator validator, ILogger<ToolDiscover
 
         try
         {
-            var searchOption = recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly;
-            var files = filePatterns
-                .SelectMany(pattern => Directory.GetFiles(directoryPath, pattern, searchOption))
-                .Distinct()
-                .ToList();
+            var files = EnumerateFilesUpToDepth(directoryPath, filePatterns, maxDepth);
 
             foreach (var file in files)
             {
@@ -280,7 +293,7 @@ public class ToolDiscoveryService(IToolValidator validator, ILogger<ToolDiscover
 
                 try
                 {
-                    var fileTools = await DiscoverToolsFromFileAsync(file, true);
+                    var fileTools = await DiscoverToolsFromFileAsync(file, true, assemblyValidator);
                     discoveredTools.AddRange(fileTools);
                 }
                 catch (Exception ex)
@@ -297,8 +310,42 @@ public class ToolDiscoveryService(IToolValidator validator, ILogger<ToolDiscover
         return discoveredTools.AsReadOnly();
     }
 
+    /// <summary>
+    /// Enumerates files matching any pattern, descending at most <paramref name="maxDepth"/> directory
+    /// levels (depth 1 = the root directory only). This honors the configured MaxDirectoryDepth instead
+    /// of collapsing any depth &gt; 1 into an unbounded recursive scan.
+    /// </summary>
+    private static IReadOnlyList<string> EnumerateFilesUpToDepth(string root, IList<string> patterns, int maxDepth)
+    {
+        var results = new List<string>();
+
+        void Walk(string dir, int depth)
+        {
+            foreach (var pattern in patterns)
+            {
+                results.AddRange(Directory.GetFiles(dir, pattern, SearchOption.TopDirectoryOnly));
+            }
+
+            if (depth >= maxDepth)
+            {
+                return;
+            }
+
+            foreach (var sub in Directory.GetDirectories(dir))
+            {
+                Walk(sub, depth + 1);
+            }
+        }
+
+        Walk(root, 1);
+        return results.Distinct().ToList();
+    }
+
     /// <inheritdoc />
-    public async Task<IReadOnlyList<DiscoveredTool>> DiscoverToolsFromFileAsync(string filePath, bool validate = true)
+    public Task<IReadOnlyList<DiscoveredTool>> DiscoverToolsFromFileAsync(string filePath, bool validate = true)
+        => DiscoverToolsFromFileAsync(filePath, validate, assemblyValidator: null);
+
+    private async Task<IReadOnlyList<DiscoveredTool>> DiscoverToolsFromFileAsync(string filePath, bool validate, Func<string, bool>? assemblyValidator)
     {
         var discoveredTools = new List<DiscoveredTool>();
 
@@ -308,12 +355,21 @@ public class ToolDiscoveryService(IToolValidator validator, ILogger<ToolDiscover
             return discoveredTools.AsReadOnly();
         }
 
+        // Gate untrusted plugin assemblies before loading: Assembly.LoadFrom executes module initializers
+        // and exposes the assembly's code, so an unvetted DLL is arbitrary code execution.
+        if (assemblyValidator != null && !assemblyValidator(filePath))
+        {
+            _logger.LogWarning("Skipping plugin assembly rejected by PluginAssemblyValidator: {FilePath}", filePath);
+            return discoveredTools.AsReadOnly();
+        }
+
         try
         {
             // Load the assembly
             Assembly assembly;
             try
             {
+                _logger.LogWarning("Loading plugin assembly from disk: {FilePath}", filePath);
                 assembly = Assembly.LoadFrom(filePath);
             }
             catch (Exception ex)

--- a/tests/Andy.Tools.Tests/Discovery/ToolDiscoveryHardeningTests.cs
+++ b/tests/Andy.Tools.Tests/Discovery/ToolDiscoveryHardeningTests.cs
@@ -1,0 +1,86 @@
+using System.Reflection;
+using Andy.Tools.Discovery;
+using Andy.Tools.Validation;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Andy.Tools.Tests.Discovery;
+
+/// <summary>
+/// Regression tests for issue #15: MaxDirectoryDepth was collapsed to a boolean (any depth &gt; 1 became
+/// an unbounded recursive scan), and plugin assemblies were loaded with no opportunity to vet them.
+/// </summary>
+public sealed class ToolDiscoveryHardeningTests : IDisposable
+{
+    private readonly string _root;
+    private readonly ToolDiscoveryService _service;
+
+    public ToolDiscoveryHardeningTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "andy_disc_hard_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+
+        var validator = new Mock<IToolValidator>();
+        validator.Setup(v => v.ValidateToolType(It.IsAny<Type>())).Returns(ValidationResult.Success());
+        _service = new ToolDiscoveryService(validator.Object, NullLogger<ToolDiscoveryService>.Instance);
+    }
+
+    [Theory]
+    [InlineData(1, false)] // root only: a file two levels down is NOT enumerated
+    [InlineData(2, true)]  // depth 2 reaches the file
+    [InlineData(5, true)]
+    public void EnumerateFilesUpToDepth_HonorsConfiguredDepth(int maxDepth, bool shouldFind)
+    {
+        var sub = Path.Combine(_root, "a");
+        Directory.CreateDirectory(sub);
+        var file = Path.Combine(sub, "plugin.dll");
+        File.WriteAllBytes(file, new byte[] { 0x4D, 0x5A }); // not a real assembly; we only test enumeration
+
+        var method = typeof(ToolDiscoveryService).GetMethod(
+            "EnumerateFilesUpToDepth", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var result = (IReadOnlyList<string>)method.Invoke(
+            null, [_root, new List<string> { "*.dll" }, maxDepth])!;
+
+        result.Any(f => string.Equals(Path.GetFullPath(f), Path.GetFullPath(file))).Should().Be(shouldFind);
+    }
+
+    [Fact]
+    public async Task PluginAssemblyValidator_RejectingFile_PreventsItFromLoading()
+    {
+        // Copy a real, loadable assembly into the plugin directory under a different file name.
+        var realAssembly = typeof(ToolDiscoveryService).Assembly.Location;
+        var pluginPath = Path.Combine(_root, "MyPlugin.dll");
+        File.Copy(realAssembly, pluginPath, overwrite: true);
+
+        var baseOptions = new ToolDiscoveryOptions
+        {
+            ScanCurrentAssembly = false,
+            ScanLoadedAssemblies = false,
+            ValidateTools = false,
+            PluginDirectories = [_root],
+            PluginFilePatterns = ["MyPlugin.dll"]
+        };
+
+        var withReject = await _service.DiscoverToolsAsync(new ToolDiscoveryOptions
+        {
+            ScanCurrentAssembly = false,
+            ScanLoadedAssemblies = false,
+            ValidateTools = false,
+            PluginDirectories = [_root],
+            PluginFilePatterns = ["MyPlugin.dll"],
+            PluginAssemblyValidator = _ => false
+        });
+        withReject.Should().BeEmpty("a rejected assembly must not be loaded or scanned");
+
+        // Sanity: without the validator, the same loadable assembly does yield tools.
+        var withoutValidator = await _service.DiscoverToolsAsync(baseOptions);
+        withoutValidator.Should().NotBeEmpty();
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+}


### PR DESCRIPTION
Closes #15.

## Problem
- `MaxDirectoryDepth` was passed as `options.MaxDirectoryDepth > 1` — any value > 1 became an unbounded `SearchOption.AllDirectories` scan, ignoring the configured depth.
- Plugin DLLs were loaded via `Assembly.LoadFrom` with no opportunity to vet them; an untrusted DLL dropped into a scanned directory is arbitrary code execution.

## Fix
- `EnumerateFilesUpToDepth`: descends at most `MaxDirectoryDepth` levels (depth 1 = root only). Direct `DiscoverToolsFromDirectoryAsync` callers keep full-recursion semantics via the `recursive` flag.
- `ToolDiscoveryOptions.PluginAssemblyValidator`: optional per-file predicate consulted **before** `LoadFrom` (enforce a strong-name / Authenticode / hash allowlist). Rejected files are skipped and logged; loading from disk now logs a warning.

Note: this adds a vetting *hook* and bounds traversal; it intentionally keeps default behavior backward-compatible. A full sandbox (collectible `AssemblyLoadContext`) is a larger design change left for follow-up.

## Tests
`ToolDiscoveryHardeningTests`: depth honoring (file two levels down found only when depth ≥ 2) via the enumerator, and a rejecting validator prevents a real loadable assembly from being scanned while the default path still discovers it. Full suite: **913 passing**.

> Stacked on #14. Last of the security cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)