### PR TITLE
fix: raise ExecutionCompleted once on permission-gate denial (#16)

### DIFF
--- a/src/Andy.Tools/Execution/ToolExecutor.cs
+++ b/src/Andy.Tools/Execution/ToolExecutor.cs
@@ -176,11 +176,13 @@ public class ToolExecutor : IToolExecutor, IDisposable
                     result.IsSuccessful = false;
                     result.ErrorMessage = reason;
                     result.SecurityViolations = [reason];
-                    result.EndTime = DateTimeOffset.UtcNow;
 
                     _securityManager.RecordViolation(request.ToolId, correlationId, reason, SecurityViolationSeverity.High);
                     SecurityViolation?.Invoke(this, new SecurityViolationEventArgs(request.ToolId, correlationId, reason, SecurityViolationSeverity.High));
-                    ExecutionCompleted?.Invoke(this, new ToolExecutionCompletedEventArgs(result));
+
+                    // Return through the finally block, which sets EndTime and raises ExecutionCompleted
+                    // exactly once — matching the other early-return paths. (Previously this branch raised
+                    // ExecutionCompleted itself and then returned, firing the event twice.)
                     return result;
                 }
             }

--- a/tests/Andy.Tools.Tests/Execution/ToolExecutorPermissionGateTests.cs
+++ b/tests/Andy.Tools.Tests/Execution/ToolExecutorPermissionGateTests.cs
@@ -81,6 +81,21 @@ public class ToolExecutorPermissionGateTests
     }
 
     [Fact]
+    public async Task Gate_deny_raises_ExecutionCompleted_exactly_once()
+    {
+        // Regression for #16: the gate-denied branch raised ExecutionCompleted itself and then returned
+        // through the finally block, which raised it again — firing the event twice.
+        var gate = new FakeGate(ToolPermissionVerdict.Deny("blocked by policy"));
+        var (exec, _) = Build(gate);
+        var completed = 0;
+        exec.ExecutionCompleted += (_, _) => Interlocked.Increment(ref completed);
+
+        await exec.ExecuteAsync(Req());
+
+        Assert.Equal(1, completed);
+    }
+
+    [Fact]
     public async Task Gate_allow_runs_the_tool()
     {
         var gate = new FakeGate(ToolPermissionVerdict.Allow);


### PR DESCRIPTION
Closes #16.

## Problem
When a request was denied by the `IToolPermissionGate`, the branch raised `ExecutionCompleted` itself **and** returned through the `finally` block, which raised the same event again — double-counting/double-logging for every gate-denied execution. The other early-return paths fire it once via the `finally`.

## Fix
Removed the manual `ExecutionCompleted?.Invoke` and `EndTime` assignment from the gate-denied branch; the `finally` block now raises it exactly once, consistent with the not-found / disabled / validation / security-violation paths.

## Tests
`Gate_deny_raises_ExecutionCompleted_exactly_once` counts invocations on denial == 1. Full suite: **914 passing**.

> Stacked on #15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)