### PR TITLE
fix(cache): stop eviction spin and fix size drift in SimpleMemoryCache (#18)

### DIFF
--- a/src/Andy.Tools/Advanced/CachingSystem/SimpleMemoryCache.cs
+++ b/src/Andy.Tools/Advanced/CachingSystem/SimpleMemoryCache.cs
@@ -81,8 +81,10 @@ public class SimpleMemoryCache : IDisposable
             entry.AbsoluteExpiration = DateTimeOffset.UtcNow.Add(options.SlidingExpiration.Value);
         }
 
-        // Check if we need to make room
-        if (_maxSizeBytes > 0 && options.SizeBytes > 0)
+        // Maintain the size accounting whenever a max size is configured. This runs even when the new
+        // entry's SizeBytes is 0 so that replacing an existing (sized) entry still subtracts its old size
+        // — otherwise _currentSizeBytes drifts upward permanently.
+        if (_maxSizeBytes > 0)
         {
             lock (_sizeLock)
             {
@@ -92,10 +94,14 @@ public class SimpleMemoryCache : IDisposable
                     _currentSizeBytes -= existingEntry.SizeBytes;
                 }
 
-                // Evict entries if necessary
+                // Evict entries if necessary. Stop if eviction makes no progress (e.g. all remaining
+                // entries are NeverEvict) — otherwise this spins forever while holding _sizeLock.
                 while (_currentSizeBytes + options.SizeBytes > _maxSizeBytes && _cache.Count > 0)
                 {
-                    EvictLeastRecentlyUsed();
+                    if (!EvictLeastRecentlyUsed())
+                    {
+                        break;
+                    }
                 }
 
                 _currentSizeBytes += options.SizeBytes;
@@ -198,29 +204,39 @@ public class SimpleMemoryCache : IDisposable
         }
     }
 
-    private void EvictLeastRecentlyUsed()
+    /// <summary>
+    /// Evicts the least-recently-used evictable entry. Returns <c>true</c> if an entry was removed, or
+    /// <c>false</c> if there was nothing to evict (so callers can stop looping instead of spinning).
+    /// </summary>
+    private bool EvictLeastRecentlyUsed()
     {
-        // Find entries eligible for eviction (not NeverEvict priority)
-        var evictableEntries = _cache
+        // Find the single best eviction candidate (not NeverEvict priority).
+        var entryToEvict = _cache
             .Where(kvp => kvp.Value.Priority != CachePriority.NeverEvict)
             .OrderBy(kvp => kvp.Value.Priority)
             .ThenBy(kvp => kvp.Value.LastAccessedAt)
-            .ToList();
+            .Select(kvp => (KeyValuePair<string, CacheEntry>?)kvp)
+            .FirstOrDefault();
 
-        if (evictableEntries.Count > 0)
+        if (entryToEvict is null)
         {
-            var entryToEvict = evictableEntries.First();
-            if (_cache.TryRemove(entryToEvict.Key, out var entry))
-            {
-                _currentSizeBytes -= entry.SizeBytes;
-
-                // Trigger eviction callbacks
-                foreach (var callback in entry.PostEvictionCallbacks)
-                {
-                    callback.EvictionCallback?.Invoke(entryToEvict.Key, entry.Value, EvictionReason.Capacity, callback.State);
-                }
-            }
+            return false;
         }
+
+        if (_cache.TryRemove(entryToEvict.Value.Key, out var entry))
+        {
+            _currentSizeBytes -= entry.SizeBytes;
+
+            // Trigger eviction callbacks
+            foreach (var callback in entry.PostEvictionCallbacks)
+            {
+                callback.EvictionCallback?.Invoke(entryToEvict.Value.Key, entry.Value, EvictionReason.Capacity, callback.State);
+            }
+
+            return true;
+        }
+
+        return false;
     }
 
     public void Dispose()

--- a/tests/Andy.Tools.Tests/Advanced/CachingSystem/SimpleMemoryCacheEvictionTests.cs
+++ b/tests/Andy.Tools.Tests/Advanced/CachingSystem/SimpleMemoryCacheEvictionTests.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Threading.Tasks;
+using Andy.Tools.Advanced.CachingSystem;
+using FluentAssertions;
+using Xunit;
+
+namespace Andy.Tools.Tests.Advanced.CachingSystem;
+
+/// <summary>
+/// Regression tests for issue #18: the eviction loop could spin forever under the size lock when all
+/// remaining entries were NeverEvict, and size accounting drifted when an entry was replaced with a
+/// zero-size entry.
+/// </summary>
+public sealed class SimpleMemoryCacheEvictionTests : IDisposable
+{
+    private readonly SimpleMemoryCache _cache = new(maxSizeBytes: 100, cleanupInterval: TimeSpan.FromMinutes(5));
+
+    public void Dispose() => _cache.Dispose();
+
+    [Fact]
+    public void Set_WhenAllEntriesAreNeverEvict_DoesNotHang()
+    {
+        // Fill the cache past capacity with NeverEvict entries.
+        _cache.Set("a", "x", new SimpleCacheEntryOptions { SizeBytes = 60, Priority = CachePriority.NeverEvict });
+        _cache.Set("b", "y", new SimpleCacheEntryOptions { SizeBytes = 60, Priority = CachePriority.NeverEvict });
+
+        // Adding another over-capacity entry must return promptly instead of spinning forever.
+        var completed = Task.Run(() =>
+            _cache.Set("c", "z", new SimpleCacheEntryOptions { SizeBytes = 60, Priority = CachePriority.NeverEvict }));
+
+        completed.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue("eviction must not spin when nothing is evictable");
+    }
+
+    [Fact]
+    public void Set_EvictsLruWhenOverCapacity()
+    {
+        _cache.Set("a", "x", new SimpleCacheEntryOptions { SizeBytes = 60, Priority = CachePriority.Normal });
+        _cache.Set("b", "y", new SimpleCacheEntryOptions { SizeBytes = 60, Priority = CachePriority.Normal });
+
+        // 'a' (LRU) should have been evicted to make room for 'b'.
+        _cache.CurrentSizeBytes.Should().BeLessThanOrEqualTo(100);
+        _cache.TryGetValue<string>("b", out _).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Set_ReplacingEntryWithZeroSize_DoesNotLeakSize()
+    {
+        _cache.Set("k", "big", new SimpleCacheEntryOptions { SizeBytes = 80 });
+        _cache.CurrentSizeBytes.Should().Be(80);
+
+        // Replacing with a zero-size entry must subtract the old size (previously it drifted upward).
+        _cache.Set("k", "small", new SimpleCacheEntryOptions { SizeBytes = 0 });
+        _cache.CurrentSizeBytes.Should().Be(0);
+    }
+}


### PR DESCRIPTION
Closes #18.

## Problem
- `EvictLeastRecentlyUsed` removed nothing when all remaining entries were `NeverEvict`, but the `Set` loop kept looping on `_cache.Count > 0` — an **infinite loop while holding `_sizeLock`**, hanging every cache writer.
- Size bookkeeping only ran inside `if (... && options.SizeBytes > 0)`, so replacing a sized entry with a zero-size one never subtracted the old size → `_currentSizeBytes` drifted upward permanently.

## Fix
- `EvictLeastRecentlyUsed` returns a `bool`; `Set` breaks the loop when it can't evict.
- Size reconciliation runs whenever `_maxSizeBytes > 0`, subtracting the replaced entry's size regardless of the new entry's size.

## Tests
`SimpleMemoryCacheEvictionTests`: all-`NeverEvict` set returns within 5s (no hang), LRU eviction works, and a zero-size replace drops `CurrentSizeBytes` to 0. Full suite: **920 passing**.

> Stacked on #17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)