### PR TITLE
fix(toolchain): concurrency, previous-result, retry error, dropped-step handling (#19)

### DIFF
--- a/src/Andy.Tools/Advanced/ToolChains/ToolChain.cs
+++ b/src/Andy.Tools/Advanced/ToolChains/ToolChain.cs
@@ -187,31 +187,49 @@ public class ToolChain(string id, string name, string description, IToolExecutor
             
             // Process all steps, including deferred ones
             var remainingSteps = new Queue<IToolChainStep>(stepQueue);
-            
+            var executedCountAtLastRefill = -1;
+
             while (remainingSteps.Count > 0 || deferredSteps.Count > 0)
             {
-                // If no more steps in queue, process deferred steps
+                // If no more steps in queue, re-queue the deferred ones — but only if we made progress
+                // since the last time we did so. Otherwise their dependencies can never be satisfied and
+                // re-queuing would loop forever.
                 if (remainingSteps.Count == 0 && deferredSteps.Count > 0)
                 {
+                    if (executedSteps.Count == executedCountAtLastRefill)
+                    {
+                        // Stuck: record an explicit error for every step that can never run, rather than
+                        // dropping them silently, then stop.
+                        foreach (var dropped in deferredSteps)
+                        {
+                            _logger.LogWarning("Step {StepId} never ran: dependencies not satisfiable", dropped.Id);
+                            result.Errors.Add(new ToolChainError
+                            {
+                                Code = "DEPENDENCY_NOT_SATISFIED",
+                                Message = $"Step '{dropped.Name}' was never executed because its dependencies were not satisfied: {string.Join(", ", dropped.Dependencies)}",
+                                StepId = dropped.Id
+                            });
+                        }
+
+                        break;
+                    }
+
                     _logger.LogDebug("Moving {Count} deferred steps back to queue", deferredSteps.Count);
-                    
-                    // Check if we can make progress - if no steps were executed since last defer, we're stuck
-                    var previousExecutedCount = executedSteps.Count;
-                    
-                    // Move deferred steps back to queue
+                    executedCountAtLastRefill = executedSteps.Count;
+
                     foreach (var deferredStep in deferredSteps)
                     {
                         remainingSteps.Enqueue(deferredStep);
                     }
                     deferredSteps.Clear();
                 }
-                
+
                 if (remainingSteps.Count == 0)
                 {
                     // No progress can be made - break to avoid infinite loop
                     break;
                 }
-                
+
                 var step = remainingSteps.Dequeue();
                 cancellationToken.ThrowIfCancellationRequested();
 
@@ -231,6 +249,7 @@ public class ToolChain(string id, string name, string description, IToolExecutor
                 {
                     var stepResult = await ExecuteStepWithRetry(step, chainContext, cancellationToken);
                     chainContext.StepResults[step.Id] = stepResult;
+                    chainContext.LastStepId = step.Id;
                     result.StepResults[step.Id] = stepResult;
 
                     if (!stepResult.IsSuccessful && step.Type != ToolChainStepType.ErrorHandler)
@@ -271,6 +290,7 @@ public class ToolChain(string id, string name, string description, IToolExecutor
                     };
 
                     chainContext.StepResults[step.Id] = stepResult;
+                    chainContext.LastStepId = step.Id;
                     result.StepResults[step.Id] = stepResult;
                     result.Errors.Add(new ToolChainError
                     {
@@ -341,6 +361,7 @@ public class ToolChain(string id, string name, string description, IToolExecutor
     {
         var maxAttempts = step.IsRetryable ? step.MaxRetries + 1 : 1;
         Exception? lastException = null;
+        ToolChainStepResult? lastFailureResult = null;
 
         for (int attempt = 1; attempt <= maxAttempts; attempt++)
         {
@@ -365,6 +386,7 @@ public class ToolChain(string id, string name, string description, IToolExecutor
                 }
 
                 lastException = result.Exception;
+                lastFailureResult = result; // keep the real failure (ErrorMessage/Data/Metadata)
             }
             catch (Exception ex)
             {
@@ -376,7 +398,14 @@ public class ToolChain(string id, string name, string description, IToolExecutor
             }
         }
 
-        // All retries failed
+        // All retries failed. Return the real last failure (preserving its ErrorMessage/Data/Metadata)
+        // rather than a synthesized result that drops the actual error.
+        if (lastFailureResult != null)
+        {
+            lastFailureResult.RetryAttempts = maxAttempts - 1;
+            return lastFailureResult;
+        }
+
         return new ToolChainStepResult
         {
             StepId = step.Id,

--- a/src/Andy.Tools/Advanced/ToolChains/ToolChainContext.cs
+++ b/src/Andy.Tools/Advanced/ToolChains/ToolChainContext.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using Andy.Tools.Core;
 
 namespace Andy.Tools.Advanced.ToolChains;
@@ -23,14 +24,16 @@ public class ToolChainContext
     public Dictionary<string, object?> InitialParameters { get; init; } = [];
 
     /// <summary>
-    /// Gets the results of completed steps.
+    /// Gets the results of completed steps. Backed by a concurrent dictionary because parallel steps
+    /// may read and write it simultaneously.
     /// </summary>
-    public Dictionary<string, ToolChainStepResult> StepResults { get; } = [];
+    public IDictionary<string, ToolChainStepResult> StepResults { get; } = new ConcurrentDictionary<string, ToolChainStepResult>();
 
     /// <summary>
-    /// Gets the shared state between steps.
+    /// Gets the shared state between steps. Backed by a concurrent dictionary because parallel steps may
+    /// read and write it simultaneously.
     /// </summary>
-    public Dictionary<string, object?> SharedState { get; } = [];
+    public IDictionary<string, object?> SharedState { get; } = new ConcurrentDictionary<string, object?>();
 
     /// <summary>
     /// Gets the execution context from the tool framework.
@@ -58,9 +61,17 @@ public class ToolChainContext
     public Action<ToolChainProgress>? OnProgress { get; set; }
 
     /// <summary>
-    /// Gets the result of the previous step.
+    /// Gets or sets the id of the most recently executed step. The orchestrator sets this so
+    /// <see cref="PreviousResult"/> is well-defined even though <see cref="StepResults"/> is unordered.
     /// </summary>
-    public object? PreviousResult => StepResults.Values.LastOrDefault()?.Data;
+    public string? LastStepId { get; set; }
+
+    /// <summary>
+    /// Gets the result data of the most recently executed step. Resolved via <see cref="LastStepId"/>
+    /// rather than dictionary enumeration order, which is not insertion-ordered.
+    /// </summary>
+    public object? PreviousResult =>
+        LastStepId != null && StepResults.TryGetValue(LastStepId, out var result) ? result?.Data : null;
 
     /// <summary>
     /// Gets a step result by step ID.

--- a/tests/Andy.Tools.Tests/Advanced/ToolChainTests.cs
+++ b/tests/Andy.Tools.Tests/Advanced/ToolChainTests.cs
@@ -518,6 +518,40 @@ public class ToolChainTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_RetriesExhausted_PreservesRealFailureResult()
+    {
+        // Regression for #19: after retries were exhausted the chain returned a synthesized
+        // "Step failed after N attempts" result, discarding the real ErrorMessage/Data.
+        var step = new Mock<IToolChainStep>();
+        step.Setup(x => x.Id).Returns("always-fails");
+        step.Setup(x => x.Name).Returns("Always Fails");
+        step.Setup(x => x.Dependencies).Returns(new List<string>());
+        step.Setup(x => x.IsRetryable).Returns(true);
+        step.Setup(x => x.MaxRetries).Returns(1);
+        step.Setup(x => x.ExecuteAsync(It.IsAny<ToolChainContext>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => new ToolChainStepResult
+            {
+                StepId = "always-fails",
+                StepName = "Always Fails",
+                IsSuccessful = false,
+                ErrorMessage = "boom-specific",
+                Data = "partial-data",
+                StartTime = DateTimeOffset.UtcNow,
+                EndTime = DateTimeOffset.UtcNow
+            });
+
+        _toolChain.AddStep(step.Object);
+
+        var result = await _toolChain.ExecuteAsync(null, _defaultContext);
+
+        var stepResult = result.StepResults["always-fails"];
+        stepResult.IsSuccessful.Should().BeFalse();
+        stepResult.ErrorMessage.Should().Be("boom-specific");
+        stepResult.Data.Should().Be("partial-data");
+        stepResult.RetryAttempts.Should().Be(1);
+    }
+
+    [Fact]
     public async Task ExecuteAsync_ShouldRespectStepDependencies()
     {
         // Arrange


### PR DESCRIPTION
Closes #19.

## Fixes
1. **Parallel-step data race** — `ToolChainContext.StepResults`/`SharedState` are now `ConcurrentDictionary`-backed (exposed as `IDictionary`). Concurrent sub-steps previously mutated plain `Dictionary` instances.
2. **Order-dependent `PreviousResult`** — now resolved via an explicit `LastStepId` set by the orchestrator, not `Dictionary.Values.LastOrDefault()` (enumeration order is not insertion order).
3. **Lost retry error** — `ExecuteStepWithRetry` returns the real last failure (`ErrorMessage`/`Data`/`Metadata`) after retries instead of a synthesized "failed after N attempts" result.
4. **Dropped steps / latent infinite loop** — the deferred-step loop captured an executed-count but never used it, so steps with unsatisfiable *runtime* dependencies could re-queue forever. It now detects no-progress and records an explicit `DEPENDENCY_NOT_SATISFIED` error per un-run step.

**Follow-up:** a per-step `ContinueOnError` flag (finding 19.5) is deferred — it changes the `IToolChainStep` surface.

## Tests
`ExecuteAsync_RetriesExhausted_PreservesRealFailureResult` plus the existing chain suite. Full suite: **921 passing**.

> Stacked on #18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)