### PR TITLE
fix(text): escape '$' for literal replacements and de-duplicate matched files (#20)

### DIFF
--- a/src/Andy.Tools/Library/Text/ReplaceTextTool.cs
+++ b/src/Andy.Tools/Library/Text/ReplaceTextTool.cs
@@ -180,15 +180,21 @@ public class ReplaceTextTool : ToolBase
             var regex = CreateSearchRegex(searchPattern, searchType, caseSensitive, wholeWordsOnly);
             var maxFileSizeBytes = (long)(maxFileSizeMb * 1024 * 1024);
 
+            // For non-regex search types the replacement is literal. Regex.Replace interprets '$' as a
+            // substitution token ($1, $&, $$), so escape it to keep literal '$' characters intact.
+            var effectiveReplacement = searchType.Equals("regex", StringComparison.OrdinalIgnoreCase)
+                ? (replacementText ?? string.Empty)
+                : (replacementText ?? string.Empty).Replace("$", "$$");
+
             if (File.Exists(safeTargetPath))
             {
                 // Process a single file
-                await ProcessFileAsync(safeTargetPath, regex, replacementText, replaceResults, replaceStats, createBackup, dryRun, maxFileSizeBytes, encodingName, context);
+                await ProcessFileAsync(safeTargetPath, regex, effectiveReplacement, replaceResults, replaceStats, createBackup, dryRun, maxFileSizeBytes, encodingName, context);
             }
             else
             {
                 // Process directory
-                await ProcessDirectoryAsync(safeTargetPath, regex, replacementText, filePatterns, excludePatterns, recursive, replaceResults, replaceStats, createBackup, dryRun, maxFileSizeBytes, encodingName, context);
+                await ProcessDirectoryAsync(safeTargetPath, regex, effectiveReplacement, filePatterns, excludePatterns, recursive, replaceResults, replaceStats, createBackup, dryRun, maxFileSizeBytes, encodingName, context);
             }
 
             ReportProgress(context, "Replacement operation completed", 100);
@@ -402,8 +408,12 @@ public class ReplaceTextTool : ToolBase
                 allFiles.AddRange(directory.GetFiles("*", searchOption));
             }
 
-            // Filter out excluded files
-            var filesToProcess = allFiles.Where(f => !ShouldExcludeFile(f.Name, f.FullName, excludePatterns)).ToList();
+            // De-duplicate by full path: overlapping file_patterns can match the same file more than once,
+            // which would otherwise apply the replacement twice (corrupting content). Then filter excludes.
+            var filesToProcess = allFiles
+                .DistinctBy(f => f.FullName)
+                .Where(f => !ShouldExcludeFile(f.Name, f.FullName, excludePatterns))
+                .ToList();
 
             var totalFiles = filesToProcess.Count;
             var processedFiles = 0;

--- a/src/Andy.Tools/Library/Text/SearchTextTool.cs
+++ b/src/Andy.Tools/Library/Text/SearchTextTool.cs
@@ -350,8 +350,12 @@ public class SearchTextTool : ToolBase
                 allFiles.AddRange(directory.GetFiles("*", searchOption));
             }
 
-            // Filter out excluded files
-            var filesToSearch = allFiles.Where(f => !ShouldExcludeFile(f.Name, f.FullName, excludePatterns)).ToList();
+            // De-duplicate by full path (overlapping file_patterns can match the same file twice, which
+            // would otherwise double-count matches), then filter excludes.
+            var filesToSearch = allFiles
+                .DistinctBy(f => f.FullName)
+                .Where(f => !ShouldExcludeFile(f.Name, f.FullName, excludePatterns))
+                .ToList();
 
             var totalFiles = filesToSearch.Count;
             var processedFiles = 0;

--- a/tests/Andy.Tools.Tests/Library/Text/ReplaceTextDollarAndDedupTests.cs
+++ b/tests/Andy.Tools.Tests/Library/Text/ReplaceTextDollarAndDedupTests.cs
@@ -1,0 +1,71 @@
+using Andy.Tools.Core;
+using Andy.Tools.Library.Text;
+using FluentAssertions;
+
+namespace Andy.Tools.Tests.Library.Text;
+
+/// <summary>
+/// Regression tests for issue #20: literal replacements mis-handled '$' (treated as a regex substitution
+/// token), and overlapping file_patterns processed the same file twice (double-applying replacements).
+/// </summary>
+public sealed class ReplaceTextDollarAndDedupTests : IDisposable
+{
+    private readonly string _dir;
+
+    public ReplaceTextDollarAndDedupTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "andy_repl_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, true); } catch { }
+    }
+
+    [Fact]
+    public async Task LiteralReplacement_WithDollarSign_IsNotTreatedAsSubstitution()
+    {
+        var file = Path.Combine(_dir, "price.txt");
+        await File.WriteAllTextAsync(file, "PRICE here");
+
+        var tool = new ReplaceTextTool();
+        await tool.InitializeAsync();
+        var result = await tool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["target_path"] = file,
+            ["search_pattern"] = "PRICE",
+            ["replacement_text"] = "$100",  // literal '$' must survive
+            ["search_type"] = "contains",
+            ["create_backup"] = false
+        }, new ToolExecutionContext { WorkingDirectory = _dir });
+
+        result.IsSuccessful.Should().BeTrue();
+        (await File.ReadAllTextAsync(file)).Should().Be("$100 here");
+    }
+
+    [Fact]
+    public async Task OverlappingFilePatterns_DoNotApplyReplacementTwice()
+    {
+        var file = Path.Combine(_dir, "doc.txt");
+        await File.WriteAllTextAsync(file, "aa");
+
+        var tool = new ReplaceTextTool();
+        await tool.InitializeAsync();
+        // Both patterns match doc.txt; without de-dup the replacement would run twice ("bb" then "cc"...
+        // actually "a"->"b" twice yields "bb" once but counted twice; use a pattern that compounds).
+        var result = await tool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["target_path"] = _dir,
+            ["search_pattern"] = "a",
+            ["replacement_text"] = "aa", // if applied twice, "aa"->"aaaa"->"aaaaaaaa"
+            ["search_type"] = "contains",
+            ["file_patterns"] = new List<string> { "*.txt", "doc.*" },
+            ["create_backup"] = false
+        }, new ToolExecutionContext { WorkingDirectory = _dir });
+
+        result.IsSuccessful.Should().BeTrue();
+        // Each 'a' -> 'aa' exactly once: "aa" (2 a's) -> "aaaa" (4 a's). Double-processing would give 8.
+        (await File.ReadAllTextAsync(file)).Should().Be("aaaa");
+    }
+}


### PR DESCRIPTION
Closes #20.

## Problem
- For non-regex `search_type`, the replacement is literal, but it was passed directly to `Regex.Replace`, which interprets `$1`, `$&`, `$$` as substitution tokens — so a literal `$` in the replacement was silently reinterpreted.
- Overlapping `file_patterns` (e.g. `["*.txt", "doc.*"]`) added the same file more than once, so `ReplaceTextTool` applied the replacement **twice** (corrupting content) and `SearchTextTool` double-counted matches.

## Fix
- Escape `$` in the replacement (`"$" → "$$"`) for non-regex search types; regex replacements are untouched.
- De-duplicate the enumerated file list by `FullName` in both tools.

## Tests
`ReplaceTextDollarAndDedupTests`: a literal `$100` replacement survives, and overlapping patterns apply the replacement exactly once (`"aa" → "aaaa"`, not `"aaaaaaaa"`). Full suite: **923 passing**.

> Stacked on #19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)