### PR TITLE
fix(json): RFC4180 CSV escaping, real deep merge, recursive diff (#21)

### DIFF
--- a/src/Andy.Tools/Library/Web/JsonProcessorTool.cs
+++ b/src/Andy.Tools/Library/Web/JsonProcessorTool.cs
@@ -315,7 +315,7 @@ public class JsonProcessorTool : ToolBase
 
         if (includeHeaders)
         {
-            csvLines.Add(string.Join(delimiter, headerList));
+            csvLines.Add(string.Join(delimiter, headerList.Select(h => EscapeCsvField(h, delimiter))));
         }
 
         // Convert each object to CSV row
@@ -326,10 +326,10 @@ public class JsonProcessorTool : ToolBase
             {
                 if (item.TryGetProperty(header, out var prop))
                 {
-                    var value = prop.ValueKind == JsonValueKind.String
-                        ? $"\"{prop.GetString()?.Replace("\"", "\"\"")}\""
-                        : prop.ToString();
-                    values.Add(value);
+                    // Use the raw string for string values; for everything else (numbers, bools, nested
+                    // objects/arrays) use the JSON text. Every field is then RFC 4180 escaped.
+                    var raw = prop.ValueKind == JsonValueKind.String ? prop.GetString() ?? string.Empty : prop.ToString();
+                    values.Add(EscapeCsvField(raw, delimiter));
                 }
                 else
                 {
@@ -343,6 +343,20 @@ public class JsonProcessorTool : ToolBase
         result.Metadata["csv_rows"] = csvLines.Count - (includeHeaders ? 1 : 0);
         result.Metadata["csv_columns"] = headerList.Count;
         return string.Join("\n", csvLines);
+    }
+
+    /// <summary>
+    /// Escapes a single CSV field per RFC 4180: a field containing the delimiter, a double quote, or a
+    /// CR/LF is wrapped in double quotes, and any embedded double quotes are doubled.
+    /// </summary>
+    private static string EscapeCsvField(string field, string delimiter)
+    {
+        var mustQuote = field.Contains('"')
+            || field.Contains('\n')
+            || field.Contains('\r')
+            || (!string.IsNullOrEmpty(delimiter) && field.Contains(delimiter, StringComparison.Ordinal));
+
+        return mustQuote ? "\"" + field.Replace("\"", "\"\"") + "\"" : field;
     }
 
     private static string FlattenJson(JsonDocument doc, JsonOperationResult result)
@@ -500,41 +514,103 @@ public class JsonProcessorTool : ToolBase
 
     private static JsonElement MergeJsonElements(JsonElement target, JsonElement source)
     {
-        // Simple merge implementation - source overwrites target
-        using var targetDoc = JsonDocument.Parse(target.GetRawText());
-        using var sourceDoc = JsonDocument.Parse(source.GetRawText());
-
+        // Deep merge: when both sides have an object at the same key, merge recursively rather than
+        // letting the source object wholesale-replace the target object.
         if (target.ValueKind == JsonValueKind.Object && source.ValueKind == JsonValueKind.Object)
         {
-            var merged = new Dictionary<string, object?>();
+            var merged = new Dictionary<string, JsonElement>();
 
             foreach (var prop in target.EnumerateObject())
             {
-                merged[prop.Name] = JsonSerializer.Deserialize<object>(prop.Value.GetRawText());
+                merged[prop.Name] = prop.Value.Clone();
             }
 
             foreach (var prop in source.EnumerateObject())
             {
-                merged[prop.Name] = JsonSerializer.Deserialize<object>(prop.Value.GetRawText());
+                merged[prop.Name] = merged.TryGetValue(prop.Name, out var existing)
+                    && existing.ValueKind == JsonValueKind.Object
+                    && prop.Value.ValueKind == JsonValueKind.Object
+                    ? MergeJsonElements(existing, prop.Value)
+                    : prop.Value.Clone();
             }
 
             return JsonSerializer.SerializeToElement(merged);
         }
 
-        return source; // If not both objects, source takes precedence
+        return source.Clone(); // If not both objects, source takes precedence
     }
 
     private static List<object> FindJsonDifferences(JsonElement left, JsonElement right)
     {
         var differences = new List<object>();
+        CompareJsonElements(left, right, "$", differences);
+        return differences;
+    }
 
+    private static void CompareJsonElements(JsonElement left, JsonElement right, string path, List<object> differences)
+    {
         if (left.ValueKind != right.ValueKind)
         {
-            differences.Add(new { path = "$", type = "type_difference", left = left.ValueKind.ToString(), right = right.ValueKind.ToString() });
+            differences.Add(new { path, type = "type_difference", left = left.ValueKind.ToString(), right = right.ValueKind.ToString() });
+            return;
         }
 
-        // Simple diff implementation - in a full implementation, this would do deep comparison
-        return differences;
+        switch (left.ValueKind)
+        {
+            case JsonValueKind.Object:
+                var leftProps = left.EnumerateObject().ToDictionary(p => p.Name, p => p.Value);
+                var rightProps = right.EnumerateObject().ToDictionary(p => p.Name, p => p.Value);
+                foreach (var key in leftProps.Keys.Union(rightProps.Keys))
+                {
+                    var childPath = $"{path}.{key}";
+                    var inLeft = leftProps.TryGetValue(key, out var lv);
+                    var inRight = rightProps.TryGetValue(key, out var rv);
+                    if (!inRight)
+                    {
+                        differences.Add(new { path = childPath, type = "removed", left = lv.ToString() });
+                    }
+                    else if (!inLeft)
+                    {
+                        differences.Add(new { path = childPath, type = "added", right = rv.ToString() });
+                    }
+                    else
+                    {
+                        CompareJsonElements(lv, rv, childPath, differences);
+                    }
+                }
+
+                break;
+
+            case JsonValueKind.Array:
+                var leftItems = left.EnumerateArray().ToList();
+                var rightItems = right.EnumerateArray().ToList();
+                for (var i = 0; i < Math.Max(leftItems.Count, rightItems.Count); i++)
+                {
+                    var childPath = $"{path}[{i}]";
+                    if (i >= rightItems.Count)
+                    {
+                        differences.Add(new { path = childPath, type = "removed", left = leftItems[i].ToString() });
+                    }
+                    else if (i >= leftItems.Count)
+                    {
+                        differences.Add(new { path = childPath, type = "added", right = rightItems[i].ToString() });
+                    }
+                    else
+                    {
+                        CompareJsonElements(leftItems[i], rightItems[i], childPath, differences);
+                    }
+                }
+
+                break;
+
+            default:
+                if (!string.Equals(left.GetRawText(), right.GetRawText(), StringComparison.Ordinal))
+                {
+                    differences.Add(new { path, type = "value_difference", left = left.ToString(), right = right.ToString() });
+                }
+
+                break;
+        }
     }
 
     private static Dictionary<string, object?> FlattenJsonElement(JsonElement element, string prefix = "")

--- a/tests/Andy.Tools.Tests/Library/Web/JsonProcessorToolTests.cs
+++ b/tests/Andy.Tools.Tests/Library/Web/JsonProcessorToolTests.cs
@@ -1,0 +1,71 @@
+using System.Text.Json;
+using Andy.Tools.Core;
+using Andy.Tools.Library.Web;
+using FluentAssertions;
+
+namespace Andy.Tools.Tests.Library.Web;
+
+/// <summary>
+/// Regression tests for issue #21: malformed CSV (unescaped delimiters/quotes), a shallow merge
+/// mislabeled "deep_merge", and a diff that only ever reported a top-level type difference.
+/// </summary>
+public class JsonProcessorToolTests
+{
+    private static async Task<ToolResult> Run(Dictionary<string, object?> p)
+    {
+        var tool = new JsonProcessorTool();
+        await tool.InitializeAsync();
+        return await tool.ExecuteAsync(p, new ToolExecutionContext());
+    }
+
+    [Fact]
+    public async Task ToCsv_QuotesFieldsContainingDelimiterOrQuote()
+    {
+        var json = """[{"name":"Doe, John","note":"say \"hi\""}]""";
+        var result = await Run(new() { ["operation"] = "to_csv", ["json_input"] = json });
+
+        result.IsSuccessful.Should().BeTrue();
+        var csv = (string)result.Data!;
+        // The comma-containing value and the quote-containing value must both be quoted/escaped.
+        csv.Should().Contain("\"Doe, John\"");
+        csv.Should().Contain("\"say \"\"hi\"\"\"");
+    }
+
+    [Fact]
+    public async Task Merge_IsDeep_NestedObjectsAreMergedNotReplaced()
+    {
+        var target = """{"a":{"x":1,"y":2},"b":1}""";
+        var source = """{"a":{"y":3,"z":4}}""";
+        var result = await Run(new() { ["operation"] = "merge", ["json_input"] = target, ["merge_json"] = source });
+
+        result.IsSuccessful.Should().BeTrue();
+        using var doc = JsonDocument.Parse((string)result.Data!);
+        var a = doc.RootElement.GetProperty("a");
+        a.GetProperty("x").GetInt32().Should().Be(1, "deep merge must keep target-only nested keys");
+        a.GetProperty("y").GetInt32().Should().Be(3, "source overrides overlapping keys");
+        a.GetProperty("z").GetInt32().Should().Be(4, "source-only nested keys are added");
+        doc.RootElement.GetProperty("b").GetInt32().Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Diff_DetectsNestedValueDifferences()
+    {
+        var left = """{"a":1,"nested":{"k":"old"}}""";
+        var right = """{"a":1,"nested":{"k":"new"}}""";
+        var result = await Run(new() { ["operation"] = "diff", ["json_input"] = left, ["merge_json"] = right });
+
+        result.IsSuccessful.Should().BeTrue();
+        ((int)result.Metadata["differences_found"]!).Should().BeGreaterThan(0);
+        ((string)result.Data!).Should().Contain("nested.k");
+    }
+
+    [Fact]
+    public async Task Diff_IdenticalDocuments_ReportsNoDifferences()
+    {
+        var doc = """{"a":1,"b":[1,2,3]}""";
+        var result = await Run(new() { ["operation"] = "diff", ["json_input"] = doc, ["merge_json"] = doc });
+
+        result.IsSuccessful.Should().BeTrue();
+        ((int)result.Metadata["differences_found"]!).Should().Be(0);
+    }
+}


### PR DESCRIPTION
Closes #21.

## Fixes
1. **`to_csv` malformed output** — only string values were quoted; headers and non-string values were emitted raw, so a delimiter/quote/newline anywhere broke the row. Now every field is RFC 4180 escaped via `EscapeCsvField` (quote when it contains the delimiter/quote/CR/LF; double internal quotes).
2. **Shallow "deep_merge"** — nested objects on both sides are now merged recursively instead of the source object wholesale-replacing the target. The metadata already advertised `deep_merge`.
3. **Non-functional `diff`** — replaced the top-level-type-only check with a recursive comparison over objects, arrays, and scalars, reporting added/removed/value-difference paths.

## Tests
`JsonProcessorToolTests`: CSV quoting of comma/quote fields, deep-merge keeps/overrides/adds nested keys, nested value diff is detected, and identical docs report 0 differences. Full suite: **927 passing**.

> Stacked on #20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)