### PR TITLE
fix(util): correct timezone Kind handling and url_decode symmetry (#22)

### DIFF
--- a/src/Andy.Tools/Library/Utilities/DateTimeTool.cs
+++ b/src/Andy.Tools/Library/Utilities/DateTimeTool.cs
@@ -516,28 +516,47 @@ public class DateTimeTool : ToolBase
 
         var parsedDate = ParseDateTimeInput(dateInput, format, CultureInfo.InvariantCulture);
 
-        // If source timezone is specified, convert from that timezone to UTC first
-        if (!string.IsNullOrEmpty(timezone))
-        {
-            var sourceTimeZone = TimeZoneInfo.FindSystemTimeZoneById(timezone);
-            parsedDate = TimeZoneInfo.ConvertTimeToUtc(parsedDate, sourceTimeZone);
-        }
+        // Treat the parsed value as wall-clock time with no implied zone. ConvertTimeToUtc throws if the
+        // Kind is Utc (or Local when the zone disagrees), and a parsed "Z"/offset input can carry Kind=Utc
+        // or Local — so normalize to Unspecified before applying the source zone.
+        var wallClock = DateTime.SpecifyKind(parsedDate, DateTimeKind.Unspecified);
 
-        // Convert to target timezone
-        var targetTimeZone = TimeZoneInfo.FindSystemTimeZoneById(targetTimezone);
-        var convertedDate = TimeZoneInfo.ConvertTimeFromUtc(parsedDate, targetTimeZone);
+        // Convert the source wall-clock time to UTC. When no source timezone is given, interpret the
+        // input in the machine's local zone (matching the reported "Local" source).
+        var sourceTimeZone = string.IsNullOrEmpty(timezone) ? TimeZoneInfo.Local : ResolveTimeZone(timezone);
+        var utc = TimeZoneInfo.ConvertTimeToUtc(wallClock, sourceTimeZone);
+
+        // Convert to the target timezone.
+        var targetTimeZone = ResolveTimeZone(targetTimezone);
+        var convertedDate = TimeZoneInfo.ConvertTimeFromUtc(utc, targetTimeZone);
 
         result.Metadata["source_timezone"] = timezone ?? "Local";
         result.Metadata["target_timezone"] = targetTimezone;
 
         return new
         {
-            original_date = parsedDate.ToString("O"),
+            original_date = wallClock.ToString("O"),
             converted_date = convertedDate.ToString("O"),
             source_timezone = timezone ?? "Local",
             target_timezone = targetTimezone,
             offset_hours = targetTimeZone.GetUtcOffset(convertedDate).TotalHours
         };
+    }
+
+    /// <summary>
+    /// Resolves a timezone id, surfacing an unknown/invalid id as a clear <see cref="ArgumentException"/>
+    /// (an invalid-parameter failure) rather than letting the raw lookup exception propagate.
+    /// </summary>
+    private static TimeZoneInfo ResolveTimeZone(string timezoneId)
+    {
+        try
+        {
+            return TimeZoneInfo.FindSystemTimeZoneById(timezoneId);
+        }
+        catch (Exception ex) when (ex is TimeZoneNotFoundException or InvalidTimeZoneException)
+        {
+            throw new ArgumentException($"Unknown or invalid timezone '{timezoneId}'.", ex);
+        }
     }
 
     private static object ValidateDateTime(string? dateInput, string? format, CultureInfo culture, DateTimeOperationResult result)

--- a/src/Andy.Tools/Library/Utilities/EncodingTool.cs
+++ b/src/Andy.Tools/Library/Utilities/EncodingTool.cs
@@ -258,8 +258,10 @@ public class EncodingTool : ToolBase
 
     private static object DecodeUrl(string input, EncodingOperationResult result)
     {
-        // First replace + with space (form-urlencoded convention), then unescape
-        var decoded = Uri.UnescapeDataString(input.Replace('+', ' '));
+        // Symmetric with EncodeUrl, which uses Uri.EscapeDataString (RFC 3986): spaces become %20 and a
+        // literal '+' stays '+'. So we must NOT translate '+' to space here, otherwise a round-trip of
+        // "a+b" would corrupt to "a b".
+        var decoded = Uri.UnescapeDataString(input);
 
         result.Metadata["original_length"] = input.Length;
         result.Metadata["decoded_length"] = decoded.Length;

--- a/tests/Andy.Tools.Tests/Library/Utilities/DateTimeAndUrlFixTests.cs
+++ b/tests/Andy.Tools.Tests/Library/Utilities/DateTimeAndUrlFixTests.cs
@@ -1,0 +1,69 @@
+using System.Text.Json;
+using Andy.Tools.Core;
+using Andy.Tools.Library.Utilities;
+using FluentAssertions;
+
+namespace Andy.Tools.Tests.Library.Utilities;
+
+/// <summary>
+/// Regression tests for issue #22: timezone conversion mishandled DateTimeKind (throwing or silently
+/// off-by-offset), and url_decode translated '+' to space asymmetrically with url_encode.
+/// </summary>
+public class DateTimeAndUrlFixTests
+{
+    private static async Task<ToolResult> RunDate(Dictionary<string, object?> p)
+    {
+        var tool = new DateTimeTool();
+        await tool.InitializeAsync();
+        return await tool.ExecuteAsync(p, new ToolExecutionContext());
+    }
+
+    private static async Task<string> RunEncoding(Dictionary<string, object?> p)
+    {
+        var tool = new EncodingTool();
+        await tool.InitializeAsync();
+        var r = await tool.ExecuteAsync(p, new ToolExecutionContext());
+        r.IsSuccessful.Should().BeTrue(r.ErrorMessage);
+        return JsonSerializer.Serialize(r.Data);
+    }
+
+    [Fact]
+    public async Task ConvertTimezone_UtcInputWithUtcSource_DoesNotThrow()
+    {
+        // A "Z" input parses as Kind=Utc; ConvertTimeToUtc(dt, ...) previously threw for that Kind.
+        var result = await RunDate(new()
+        {
+            ["operation"] = "convert_timezone",
+            ["date_input"] = "2024-01-15T12:00:00Z",
+            ["timezone"] = "UTC",
+            ["target_timezone"] = "UTC"
+        });
+
+        // The regression is that a Kind=Utc input no longer throws during conversion.
+        result.IsSuccessful.Should().BeTrue(result.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task ConvertTimezone_UnknownTimezone_FailsCleanly()
+    {
+        var result = await RunDate(new()
+        {
+            ["operation"] = "convert_timezone",
+            ["date_input"] = "2024-01-15T12:00:00",
+            ["target_timezone"] = "Mars/Olympus_Mons"
+        });
+
+        result.IsSuccessful.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task UrlEncodeDecode_RoundTripsLiteralPlus()
+    {
+        var encoded = await RunEncoding(new() { ["operation"] = "url_encode", ["input_text"] = "a+b c" });
+        var encodedValue = JsonDocument.Parse(encoded).RootElement.GetProperty("encoded").GetString()!;
+
+        var decoded = await RunEncoding(new() { ["operation"] = "url_decode", ["input_text"] = encodedValue });
+        JsonDocument.Parse(decoded).RootElement.GetProperty("decoded").GetString()
+            .Should().Be("a+b c", "encode/decode must be symmetric for a literal '+'");
+    }
+}

--- a/tests/Andy.Tools.Tests/Library/Utilities/EncodingToolTests.cs
+++ b/tests/Andy.Tools.Tests/Library/Utilities/EncodingToolTests.cs
@@ -184,7 +184,9 @@ public class EncodingToolTests : IDisposable
         var parameters = new Dictionary<string, object?>
         {
             ["operation"] = "url_decode",
-            ["input_text"] = "Hello+World%21+Special+chars%3A+%26%3D%3F"
+            // RFC 3986 form (spaces as %20) — matches what url_encode (Uri.EscapeDataString) produces.
+            // '+' is a literal '+', not a space, so encode/decode round-trip correctly.
+            ["input_text"] = "Hello%20World%21%20Special%20chars%3A%20%26%3D%3F"
         };
 
         var context = new ToolExecutionContext();


### PR DESCRIPTION
Closes #22.

## Fixes
- **`DateTimeTool.ConvertTimezone`** — normalizes the parsed value to `DateTimeKind.Unspecified` before applying the source zone (`ConvertTimeToUtc` throws when `Kind` is `Utc`/mismatched `Local`), interprets a missing source timezone as `Local` (instead of silently treating the value as UTC), and resolves timezone ids via a helper that converts an unknown/invalid id into a clear `ArgumentException` rather than letting the raw lookup exception escape.
- **`EncodingTool.DecodeUrl`** — no longer translates `+` to space. `url_encode` uses `Uri.EscapeDataString` (RFC 3986: space → `%20`, `+` stays `+`), so translating `+` on decode corrupted round-trips of a literal `+` (`"a+b"` → `"a b"`).

## Tests
`DateTimeAndUrlFixTests`: `Z`-input conversion no longer throws, an unknown timezone fails cleanly, and url encode→decode round-trips a literal `+`. Updated the existing url-decode test to RFC 3986 (`%20`) form. Full suite: **930 passing**.

> Stacked on #21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)