### PR TITLE
fix(fs): copy progress O(n^2), post-delete size, same-path copy, backup collisions (#23)

### DIFF
--- a/src/Andy.Tools/Library/Common/ToolHelpers.cs
+++ b/src/Andy.Tools/Library/Common/ToolHelpers.cs
@@ -279,6 +279,16 @@ public static class ToolHelpers
     }
 
     /// <summary>
+    /// Builds a unique backup path for a file. Uses a high-resolution timestamp plus a short random
+    /// token so multiple backups of the same file within the same second do not overwrite each other.
+    /// </summary>
+    /// <param name="originalPath">The path of the file being backed up.</param>
+    public static string GetBackupPath(string originalPath)
+    {
+        return $"{originalPath}.backup.{DateTime.UtcNow:yyyyMMddHHmmssfffffff}.{Guid.NewGuid().ToString("N")[..8]}";
+    }
+
+    /// <summary>
     /// Safely writes text to a file with backup creation.
     /// </summary>
     /// <param name="filePath">The file path to write.</param>
@@ -293,8 +303,7 @@ public static class ToolHelpers
         // Create backup if file exists and backup is requested
         if (createBackup && File.Exists(filePath))
         {
-            var backupPath = $"{filePath}.backup.{DateTime.UtcNow:yyyyMMddHHmmss}";
-            File.Copy(filePath, backupPath, true);
+            File.Copy(filePath, GetBackupPath(filePath), true);
         }
 
         // Ensure directory exists

--- a/src/Andy.Tools/Library/FileSystem/CopyFileTool.cs
+++ b/src/Andy.Tools/Library/FileSystem/CopyFileTool.cs
@@ -152,6 +152,12 @@ public partial class CopyFileTool : ToolBase
                 return ToolResults.Failure($"Path '{safeDestinationPath}' is not within allowed paths", "PATH_NOT_ALLOWED");
             }
 
+            // Reject copying a path onto itself (File.Copy(src, src, true) throws a confusing IOException).
+            if (string.Equals(safeSourcePath, safeDestinationPath, ToolHelpers.PathComparison))
+            {
+                return ToolResults.Failure("Source and destination paths are the same", "SAME_PATH");
+            }
+
             if (!File.Exists(safeSourcePath) && !Directory.Exists(safeSourcePath))
             {
                 return ToolResults.Failure(
@@ -169,6 +175,9 @@ public partial class CopyFileTool : ToolBase
             {
                 // For directories, if destination doesn't exist or is not a directory,
                 // treat destination as the target directory name
+                // Compute the total file count once up front; it is only used for progress reporting and
+                // walking the whole subtree per file is an O(n^2) I/O blowup on large trees.
+                var totalFiles = CountFiles(new DirectoryInfo(safeSourcePath), recursive, excludePatterns);
                 await CopyDirectoryAsync(
                     safeSourcePath,
                     safeDestinationPath,
@@ -179,7 +188,8 @@ public partial class CopyFileTool : ToolBase
                     excludePatterns,
                     createDestinationDirectory,
                     copyStats,
-                    context
+                    context,
+                    totalFiles
                 );
             }
             else
@@ -310,7 +320,8 @@ public partial class CopyFileTool : ToolBase
         List<string> excludePatterns,
         bool createDestinationDirectory,
         CopyStatistics stats,
-        ToolExecutionContext context)
+        ToolExecutionContext context,
+        int totalFiles)
     {
         var sourceDir = new DirectoryInfo(sourcePath);
         var destinationDir = new DirectoryInfo(destinationPath);
@@ -346,8 +357,8 @@ public partial class CopyFileTool : ToolBase
                 var destFile = Path.Combine(destinationPath, file.Name);
                 await CopyFileAsync(file.FullName, destFile, overwrite, preserveTimestamps, false, stats, context);
 
-                // Update progress
-                var progressPercent = Math.Min(95, 10 + (stats.FilesCopied * 80 / Math.Max(1, CountFiles(sourceDir, recursive, excludePatterns))));
+                // Update progress (totalFiles is computed once by the caller).
+                var progressPercent = Math.Min(95, 10 + (stats.FilesCopied * 80 / Math.Max(1, totalFiles)));
                 ReportProgress(context, $"Copied: {file.Name}", progressPercent);
             }
             catch (Exception ex)
@@ -381,7 +392,8 @@ public partial class CopyFileTool : ToolBase
                         excludePatterns,
                         createDestinationDirectory,
                         stats,
-                        context
+                        context,
+                        totalFiles
                     );
                 }
                 catch (Exception ex)

--- a/src/Andy.Tools/Library/FileSystem/DeleteFileTool.cs
+++ b/src/Andy.Tools/Library/FileSystem/DeleteFileTool.cs
@@ -394,9 +394,11 @@ public class DeleteFileTool : ToolBase
                     file.IsReadOnly = false;
                 }
 
+                // Capture the size before deleting; FileInfo.Length throws once the file is gone.
+                var fileSize = file.Length;
                 file.Delete();
                 stats.FilesDeleted++;
-                stats.BytesDeleted += file.Length;
+                stats.BytesDeleted += fileSize;
             }
             catch (Exception ex)
             {

--- a/src/Andy.Tools/Library/FileSystem/MoveFileTool.cs
+++ b/src/Andy.Tools/Library/FileSystem/MoveFileTool.cs
@@ -163,7 +163,7 @@ public partial class MoveFileTool : ToolBase
             string? backupPath = null;
             if (backupExisting && destinationExists)
             {
-                backupPath = $"{safeDestinationPath}.backup.{DateTime.UtcNow:yyyyMMddHHmmss}";
+                backupPath = ToolHelpers.GetBackupPath(safeDestinationPath);
                 ReportProgress(context, "Creating backup...", 30);
 
                 if (isDirectory)

--- a/src/Andy.Tools/Library/FileSystem/WriteFileTool.cs
+++ b/src/Andy.Tools/Library/FileSystem/WriteFileTool.cs
@@ -129,7 +129,7 @@ public class WriteFileTool : ToolBase
             string? backupPath = null;
             if (createBackup && fileExists && !append)
             {
-                backupPath = $"{safePath}.backup.{DateTime.UtcNow:yyyyMMddHHmmss}";
+                backupPath = ToolHelpers.GetBackupPath(safePath);
                 File.Copy(safePath, backupPath, true);
                 ReportProgress(context, "Created backup file", 50);
             }

--- a/src/Andy.Tools/Library/Text/ReplaceTextTool.cs
+++ b/src/Andy.Tools/Library/Text/ReplaceTextTool.cs
@@ -352,7 +352,7 @@ public class ReplaceTextTool : ToolBase
                     // Create backup if requested
                     if (createBackup)
                     {
-                        var backupPath = $"{filePath}.backup.{DateTime.UtcNow:yyyyMMddHHmmss}";
+                        var backupPath = ToolHelpers.GetBackupPath(filePath);
                         File.Copy(filePath, backupPath, true);
                         result.BackupPath = backupPath;
                         result.BackupCreated = true;

--- a/tests/Andy.Tools.Tests/Library/FileSystem/FileSystemPerfCorrectnessTests.cs
+++ b/tests/Andy.Tools.Tests/Library/FileSystem/FileSystemPerfCorrectnessTests.cs
@@ -1,0 +1,77 @@
+using Andy.Tools.Core;
+using Andy.Tools.Library.Common;
+using Andy.Tools.Library.FileSystem;
+using FluentAssertions;
+
+namespace Andy.Tools.Tests.Library.FileSystem;
+
+/// <summary>
+/// Regression tests for issue #23: CopyFile lacked a same-path guard, deleted-file size tallying read
+/// FileInfo.Length after deletion, and backup paths used a 1-second-resolution suffix that overwrote.
+/// </summary>
+public sealed class FileSystemPerfCorrectnessTests : IDisposable
+{
+    private readonly string _dir;
+
+    public FileSystemPerfCorrectnessTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "andy_fsperf_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, true); } catch { }
+    }
+
+    [Fact]
+    public async Task Copy_SourceEqualsDestination_IsRejected()
+    {
+        var file = Path.Combine(_dir, "f.txt");
+        await File.WriteAllTextAsync(file, "data");
+
+        var tool = new CopyFileTool();
+        await tool.InitializeAsync();
+        var result = await tool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["source_path"] = file,
+            ["destination_path"] = file,
+            ["overwrite"] = true
+        }, new ToolExecutionContext { WorkingDirectory = _dir });
+
+        result.IsSuccessful.Should().BeFalse();
+        (await File.ReadAllTextAsync(file)).Should().Be("data");
+    }
+
+    [Fact]
+    public async Task DeleteDirectory_ReportsBytesDeleted()
+    {
+        var sub = Path.Combine(_dir, "tree");
+        Directory.CreateDirectory(sub);
+        await File.WriteAllTextAsync(Path.Combine(sub, "a.txt"), new string('x', 100));
+
+        var tool = new DeleteFileTool();
+        await tool.InitializeAsync();
+        var result = await tool.ExecuteAsync(new Dictionary<string, object?>
+        {
+            ["target_path"] = sub,
+            ["recursive"] = true
+        }, new ToolExecutionContext { WorkingDirectory = _dir });
+
+        // The key regression: deleting files in a directory no longer throws while tallying size.
+        result.IsSuccessful.Should().BeTrue(result.ErrorMessage);
+        Directory.Exists(sub).Should().BeFalse();
+    }
+
+    [Fact]
+    public void GetBackupPath_ProducesUniquePathsWithinSameSecond()
+    {
+        var paths = new HashSet<string>();
+        for (var i = 0; i < 50; i++)
+        {
+            paths.Add(ToolHelpers.GetBackupPath("/tmp/file.txt"));
+        }
+
+        paths.Count.Should().Be(50, "backup paths must not collide within the same second");
+    }
+}


### PR DESCRIPTION
Closes #23.

## Fixes
- **O(n²) copy progress** — `CopyDirectoryAsync` called `CountFiles` (a full recursive subtree walk) once *per file copied*. The total is now computed once and threaded through the recursion.
- **`FileInfo.Length` after delete** — the directory-delete path read `file.Length` after `file.Delete()` (throws `FileNotFoundException`); the size is now captured before deletion.
- **Missing same-path guard in CopyFile** — `source == destination` now returns `SAME_PATH` instead of a confusing `IOException`, matching `MoveFileTool`.
- **Lossy backup suffix** — 1-second-resolution suffixes overwrote each other on rapid writes. New `ToolHelpers.GetBackupPath` uses a high-resolution timestamp + short random token; applied across Write/Move/Replace and `WriteTextFileAsync`.

## Tests
`FileSystemPerfCorrectnessTests`: same-path copy rejected, recursive delete reports success without throwing, and 50 backup paths within the same second are unique. Full suite: **933 passing**.

> Stacked on #22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)