### PR TITLE
fix(system): dispose Process in ProcessInfo by-id lookup (#25)

### DIFF
--- a/src/Andy.Tools/Library/System/ProcessInfoTool.cs
+++ b/src/Andy.Tools/Library/System/ProcessInfoTool.cs
@@ -170,7 +170,9 @@ public class ProcessInfoTool : ToolBase
     {
         try
         {
-            var process = Process.GetProcessById(processId);
+            // Dispose the Process so its OS handle is released; the by-name/all paths already do this,
+            // but this path leaked a SafeProcessHandle on every call.
+            using var process = Process.GetProcessById(processId);
             return await CreateProcessInfoAsync(process, detailed, context);
         }
         catch (ArgumentException)

--- a/tests/Andy.Tools.Tests/Library/System/ProcessInfoToolTests.cs
+++ b/tests/Andy.Tools.Tests/Library/System/ProcessInfoToolTests.cs
@@ -1,0 +1,49 @@
+using Andy.Tools.Core;
+using Andy.Tools.Library.System;
+using FluentAssertions;
+
+namespace Andy.Tools.Tests.Library.System;
+
+/// <summary>
+/// Tests for ProcessInfoTool (previously untested — issue #34) including the by-id handle-leak fix (#25).
+/// </summary>
+public class ProcessInfoToolTests
+{
+    private static async Task<ToolResult> Run(Dictionary<string, object?> p)
+    {
+        var tool = new ProcessInfoTool();
+        await tool.InitializeAsync();
+        return await tool.ExecuteAsync(p, new ToolExecutionContext());
+    }
+
+    [Fact]
+    public async Task QueryByCurrentProcessId_ReturnsThatProcess()
+    {
+        var pid = Environment.ProcessId;
+        var result = await Run(new() { ["process_id"] = pid });
+
+        result.IsSuccessful.Should().BeTrue(result.ErrorMessage);
+        result.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task QueryByNonExistentProcessId_DoesNotThrow()
+    {
+        // A pid that is extremely unlikely to exist; the tool must fail/empty gracefully, not throw.
+        var result = await Run(new() { ["process_id"] = 2_000_000_000 });
+        result.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task RepeatedByIdQueries_CompleteWithoutError()
+    {
+        // The by-id path used to leak a process handle on each call (it never disposed the Process).
+        // This exercises that path many times; with the `using` fix it completes cleanly.
+        var pid = Environment.ProcessId;
+        for (var i = 0; i < 200; i++)
+        {
+            var result = await Run(new() { ["process_id"] = pid });
+            result.IsSuccessful.Should().BeTrue();
+        }
+    }
+}


### PR DESCRIPTION
Closes #25.

## Problem
`ProcessInfoTool.GetProcessByIdAsync` called `Process.GetProcessById` but never disposed the `Process`, leaking a `SafeProcessHandle` on every `process_info` call with a `process_id`. The by-name and all-processes paths already dispose.

## Fix
`using var process = Process.GetProcessById(processId);`

## Tests
First tests for `ProcessInfoTool`: query by current pid succeeds, a non-existent pid fails gracefully (no throw), and 200 repeated by-id lookups complete cleanly. Full suite: **938 passing**.

> Stacked on #24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)