### PR TITLE
fix(exec): baseline-relative memory accounting and disposable ResourceMonitor (#26)

### DIFF
--- a/src/Andy.Tools/Execution/ISecurityManager.cs
+++ b/src/Andy.Tools/Execution/ISecurityManager.cs
@@ -125,7 +125,7 @@ public class SecurityViolation
 /// <summary>
 /// Interface for monitoring resource usage during tool execution.
 /// </summary>
-public interface IResourceMonitor
+public interface IResourceMonitor : IDisposable
 {
     /// <summary>
     /// Starts monitoring resource usage for a tool execution.

--- a/src/Andy.Tools/Execution/ResourceMonitor.cs
+++ b/src/Andy.Tools/Execution/ResourceMonitor.cs
@@ -75,7 +75,10 @@ public class ResourceMonitor : IResourceMonitor
     {
         try
         {
-            var currentProcess = Process.GetCurrentProcess();
+            // Refresh so WorkingSet64 reflects the current value rather than a cached one, and dispose
+            // the Process to avoid leaking a handle on every tick.
+            using var currentProcess = Process.GetCurrentProcess();
+            currentProcess.Refresh();
             var currentMemory = currentProcess.WorkingSet64;
 
             foreach (var session in _sessions.Values)
@@ -126,7 +129,18 @@ internal class ResourceMonitoringSession(string correlationId, ToolResourceLimit
     private readonly HashSet<string> _accessedFiles = [];
     private readonly HashSet<string> _accessedHosts = [];
     private readonly HashSet<string> _executedProcesses = [];
+
+    // Process working set when this session began. Memory cannot be attributed per managed task, so we
+    // report this session's memory as the process growth since it started (best-effort, process-relative).
+    private readonly long _baselineMemoryBytes = ReadProcessWorkingSet();
     private bool _disposed;
+
+    private static long ReadProcessWorkingSet()
+    {
+        using var process = Process.GetCurrentProcess();
+        process.Refresh();
+        return process.WorkingSet64;
+    }
 
     /// <inheritdoc />
     public string CorrelationId { get; } = correlationId;
@@ -228,14 +242,19 @@ internal class ResourceMonitoringSession(string correlationId, ToolResourceLimit
 
         lock (_lockObject)
         {
-            if (memoryBytes > CurrentUsage.PeakMemoryBytes)
+            // Attribute the process growth since this session started, rather than the whole-process
+            // working set (which would make every concurrent session report identical memory and trip a
+            // single tool's limit as soon as the process total exceeded it).
+            var attributed = Math.Max(0, memoryBytes - _baselineMemoryBytes);
+
+            if (attributed > CurrentUsage.PeakMemoryBytes)
             {
-                CurrentUsage.PeakMemoryBytes = memoryBytes;
+                CurrentUsage.PeakMemoryBytes = attributed;
             }
 
             // Update average memory (simple running average)
             var samples = (DateTimeOffset.UtcNow - StartTime).TotalSeconds;
-            CurrentUsage.AverageMemoryBytes = samples > 0 ? (long)(((CurrentUsage.AverageMemoryBytes * (samples - 1)) + memoryBytes) / samples) : memoryBytes;
+            CurrentUsage.AverageMemoryBytes = samples > 0 ? (long)(((CurrentUsage.AverageMemoryBytes * (samples - 1)) + attributed) / samples) : attributed;
 
             // Check memory limit
             if (CurrentUsage.PeakMemoryBytes > Limits.MaxMemoryBytes && !_exceededLimits.Contains("memory"))

--- a/tests/Andy.Tools.Tests/Execution/ResourceMonitorMemoryTests.cs
+++ b/tests/Andy.Tools.Tests/Execution/ResourceMonitorMemoryTests.cs
@@ -1,0 +1,40 @@
+using Andy.Tools.Core;
+using Andy.Tools.Execution;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Andy.Tools.Tests.Execution;
+
+/// <summary>
+/// Regression tests for issue #26: memory was reported as the whole-process working set (so a fresh
+/// session immediately showed huge usage and tripped tiny limits), and IResourceMonitor was not
+/// IDisposable so the container never disposed the polling timer.
+/// </summary>
+public class ResourceMonitorMemoryTests
+{
+    [Fact]
+    public void NewSession_ReportsBaselineRelativeMemory_NotWholeProcess()
+    {
+        using var monitor = new ResourceMonitor(NullLogger<ResourceMonitor>.Instance);
+        var session = monitor.StartMonitoring("c1", new ToolResourceLimits { MaxMemoryBytes = 64L * 1024 * 1024 });
+
+        // A just-started session that has allocated nothing must not report the entire process working
+        // set (hundreds of MB). Feed the current process memory as the sampler would.
+        using var proc = global::System.Diagnostics.Process.GetCurrentProcess();
+        proc.Refresh();
+        session.UpdateMemoryUsage(proc.WorkingSet64);
+
+        // Delta from baseline should be small — definitely far below the full working set.
+        session.CurrentUsage.PeakMemoryBytes.Should().BeLessThan(proc.WorkingSet64 / 2);
+    }
+
+    [Fact]
+    public void ResourceMonitor_IsDisposableThroughInterface()
+    {
+        IResourceMonitor monitor = new ResourceMonitor(NullLogger<ResourceMonitor>.Instance);
+        // IResourceMonitor now extends IDisposable, so the DI container can dispose the timer.
+        monitor.Should().BeAssignableTo<IDisposable>();
+        monitor.Dispose();
+    }
+}

--- a/tests/Andy.Tools.Tests/Execution/ResourceMonitorTests.cs
+++ b/tests/Andy.Tools.Tests/Execution/ResourceMonitorTests.cs
@@ -178,14 +178,22 @@ public class ResourceMonitorTests : IDisposable
         var correlationId = "test-correlation-id";
         var session = _resourceMonitor.StartMonitoring(correlationId, _testLimits);
 
+        // Memory is now reported relative to the session's baseline (process working set at start), so
+        // feed baseline + a large delta. Large deltas (100s of MB) dwarf any baseline drift between the
+        // session's capture and ours, keeping the assertion stable.
+        using var proc = global::System.Diagnostics.Process.GetCurrentProcess();
+        proc.Refresh();
+        var b = proc.WorkingSet64;
+        const long mb = 1024 * 1024;
+
         // Act
-        session.UpdateMemoryUsage(100);
-        session.UpdateMemoryUsage(200);
-        session.UpdateMemoryUsage(150);
+        session.UpdateMemoryUsage(b + (100 * mb));
+        session.UpdateMemoryUsage(b + (200 * mb));
+        session.UpdateMemoryUsage(b + (150 * mb));
 
         // Assert
         var usage = session.CurrentUsage;
-        Assert.Equal(200, usage.PeakMemoryBytes); // Peak should be 200
+        Assert.InRange(usage.PeakMemoryBytes, 199 * mb, 201 * mb); // Peak ~= 200MB above baseline
         Assert.True(usage.AverageMemoryBytes > 0); // Average should be calculated
     }
 
@@ -237,8 +245,10 @@ public class ResourceMonitorTests : IDisposable
 
         var session = _resourceMonitor.StartMonitoring(correlationId, _testLimits);
 
-        // Act - exceed memory limit (limit is 1MB = 1,048,576 bytes)
-        session.UpdateMemoryUsage(2 * 1024 * 1024); // 2MB
+        // Act - exceed memory limit (limit is 1MB). Memory is baseline-relative, so feed baseline + 2MB.
+        using var proc = global::System.Diagnostics.Process.GetCurrentProcess();
+        proc.Refresh();
+        session.UpdateMemoryUsage(proc.WorkingSet64 + (2 * 1024 * 1024)); // ~2MB above baseline
 
         // Assert
         Assert.True(limitExceededEventFired);


### PR DESCRIPTION
Closes #26.

## Fixes
- **Process-wide memory attributed to every session** — each session now captures the process working set at start and reports memory as the *growth* since then (documented best-effort, process-relative). Previously every concurrent tool reported the identical whole-process working set and would trip its `MaxMemoryBytes` as soon as the process total exceeded it.
- **Stale/leaky sampling** — the timer callback now calls `Process.Refresh()` before reading `WorkingSet64` and disposes the `Process` each tick.
- **Timer leak** — `IResourceMonitor` now extends `IDisposable`, so the DI container disposes the 1-second polling timer (the class already implemented `Dispose`).

Note: this makes per-tool memory a best-effort *process-relative* signal. True per-task hard limits need OS isolation (job objects/cgroups) and are out of scope.

## Tests
`ResourceMonitorMemoryTests`: a fresh session does not report the whole working set, and the monitor is `IDisposable` via the interface. Updated two existing tests to the baseline-relative semantics. Full suite: **940 passing**.

> Stacked on #25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)