### PR TITLE
fix(di): bind output-limiter options without BuildServiceProvider (#27)

### DIFF
--- a/src/Andy.Tools/ServiceCollectionExtensions.cs
+++ b/src/Andy.Tools/ServiceCollectionExtensions.cs
@@ -10,6 +10,7 @@ using Andy.Tools.Validation;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 
 namespace Andy.Tools;
 
@@ -52,12 +53,13 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<IToolExecutor, ToolExecutor>();
         services.TryAddSingleton<IPermissionProfileService, PermissionProfileService>();
 
-        // Configure output limiter options
-        services.Configure<ToolOutputLimiterOptions>(configuration =>
-        {
-            var config = services.BuildServiceProvider().GetService<IConfiguration>();
-            config?.GetSection(ToolOutputLimiterOptions.SectionName).Bind(configuration);
-        });
+        // Configure output limiter options from IConfiguration if one is registered. Use an
+        // IConfigureOptions that resolves IConfiguration from the real container at options-build time,
+        // instead of calling services.BuildServiceProvider() here (which builds a throwaway container,
+        // duplicates/leaks singletons, and reads from the wrong provider — ASP0000).
+        services.AddSingleton<IConfigureOptions<ToolOutputLimiterOptions>>(sp =>
+            new ConfigureOptions<ToolOutputLimiterOptions>(opt =>
+                sp.GetService<IConfiguration>()?.GetSection(ToolOutputLimiterOptions.SectionName).Bind(opt)));
 
         // Integration services removed - they depend on Andy.GeminiClient
 

--- a/tests/Andy.Tools.Tests/ServiceCollectionOptionsBindingTests.cs
+++ b/tests/Andy.Tools.Tests/ServiceCollectionOptionsBindingTests.cs
@@ -1,0 +1,53 @@
+using System.Collections.Generic;
+using Andy.Tools;
+using Andy.Tools.Core.OutputLimiting;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Andy.Tools.Tests;
+
+/// <summary>
+/// Regression test for issue #27: output-limiter options were bound by calling
+/// services.BuildServiceProvider() inside a Configure lambda (a throwaway container, ASP0000). Binding
+/// now flows through an IConfigureOptions that reads IConfiguration from the real container.
+/// </summary>
+public class ServiceCollectionOptionsBindingTests
+{
+    [Fact]
+    public void OutputLimiterOptions_BindFromRegisteredConfiguration()
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [$"{ToolOutputLimiterOptions.SectionName}:MaxOutputCharacters"] = "1234",
+                [$"{ToolOutputLimiterOptions.SectionName}:MaxFileListEntries"] = "7",
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(config);
+        services.AddAndyTools();
+
+        using var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptions<ToolOutputLimiterOptions>>().Value;
+
+        options.MaxOutputCharacters.Should().Be(1234);
+        options.MaxFileListEntries.Should().Be(7);
+    }
+
+    [Fact]
+    public void Registration_WithoutConfiguration_DoesNotThrow_AndUsesDefaults()
+    {
+        // No IConfiguration registered — binding must be a no-op (defaults retained), not a failure.
+        var services = new ServiceCollection();
+        services.AddAndyTools();
+
+        using var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptions<ToolOutputLimiterOptions>>().Value;
+
+        options.MaxOutputCharacters.Should().Be(50_000); // documented default
+    }
+}


### PR DESCRIPTION
Addresses the primary, unambiguous item in #27.

## Fix
`AddAndyTools` configured `ToolOutputLimiterOptions` via `services.BuildServiceProvider()` **inside a `Configure` lambda** — the classic ASP0000 anti-pattern: it builds a throwaway second container, duplicates/leaks singletons, and resolves `IConfiguration` from the wrong provider. Replaced with an `IConfigureOptions<ToolOutputLimiterOptions>` whose factory reads `IConfiguration` from the **real** container at options-build time, preserving the original tolerance for no `IConfiguration` being registered.

## Deferred (kept honest)
The other review items under #27 are intentionally **not** in this PR:
- *Singleton tool-creation capturing the root provider* — needs a per-execution `IServiceScope` redesign plus coverage; risky to change blind.
- *Catch-all `IToolChain` registration* — existing tests (`ServiceCollectionExtensionsTests`) resolve `IToolChain` from DI and expect non-null, so removing it would break them. Needs a separate decision.

I left #27 open and noted these in the commit so they aren't lost.

## Tests
`ServiceCollectionOptionsBindingTests`: options bind from a registered `IConfiguration`, and registration without any `IConfiguration` doesn't throw (defaults retained). Full suite: **942 passing**.

> Stacked on #26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)