### PR TITLE
fix(validation): coerce JsonElement params and normalize AllowedValues equality (#28)

### DIFF
--- a/src/Andy.Tools/Validation/ToolValidator.cs
+++ b/src/Andy.Tools/Validation/ToolValidator.cs
@@ -294,6 +294,10 @@ public class ToolValidator : IToolValidator
     {
         var errors = new List<ValidationError>();
 
+        // Parameters deserialized from JSON arrive as JsonElement; coerce to the corresponding CLR type
+        // so the type/range/enum checks below see a bool/string/number rather than rejecting everything.
+        value = NormalizeJsonElement(value) ?? value;
+
         // Type validation
         switch (parameter.Type.ToLowerInvariant())
         {
@@ -379,16 +383,51 @@ public class ToolValidator : IToolValidator
                 break;
         }
 
-        // Validate allowed values
+        // Validate allowed values. Compare by normalized invariant string so an int allowed-value matches
+        // a long/double/JsonElement-sourced value of the same magnitude (default object equality would not).
         if (parameter.AllowedValues != null && parameter.AllowedValues.Count > 0)
         {
-            if (!parameter.AllowedValues.Contains(value))
+            if (!parameter.AllowedValues.Any(allowed => ValuesEqual(allowed, value)))
             {
                 errors.Add(new ValidationError("PARAMETER_VALUE_NOT_ALLOWED", $"Parameter '{parameter.Name}' value is not in the list of allowed values", parameter.Name, value));
             }
         }
 
         return errors;
+    }
+
+    private static object? NormalizeJsonElement(object? value)
+    {
+        if (value is not System.Text.Json.JsonElement element)
+        {
+            return value;
+        }
+
+        return element.ValueKind switch
+        {
+            System.Text.Json.JsonValueKind.String => element.GetString(),
+            System.Text.Json.JsonValueKind.True => true,
+            System.Text.Json.JsonValueKind.False => false,
+            System.Text.Json.JsonValueKind.Number => element.TryGetInt64(out var l) ? l : element.GetDouble(),
+            System.Text.Json.JsonValueKind.Null => null,
+            System.Text.Json.JsonValueKind.Array => element.EnumerateArray().Select(e => NormalizeJsonElement(e)).ToList(),
+            _ => value // Object/Undefined: leave as-is (the "object" type accepts it)
+        };
+    }
+
+    private static bool ValuesEqual(object? a, object? b)
+    {
+        a = NormalizeJsonElement(a);
+        b = NormalizeJsonElement(b);
+        if (a == null || b == null)
+        {
+            return a == null && b == null;
+        }
+
+        return string.Equals(
+            Convert.ToString(a, System.Globalization.CultureInfo.InvariantCulture),
+            Convert.ToString(b, System.Globalization.CultureInfo.InvariantCulture),
+            StringComparison.Ordinal);
     }
 
     private static bool IsNumericValue(object value, out double numericValue)

--- a/tests/Andy.Tools.Tests/Validation/ToolValidatorJsonCoercionTests.cs
+++ b/tests/Andy.Tools.Tests/Validation/ToolValidatorJsonCoercionTests.cs
@@ -1,0 +1,86 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using Andy.Tools.Core;
+using Andy.Tools.Validation;
+using FluentAssertions;
+using Xunit;
+
+namespace Andy.Tools.Tests.Validation;
+
+/// <summary>
+/// Regression tests for issue #28: JSON-sourced parameter values (JsonElement) were rejected by the
+/// type checks, and AllowedValues used boxed-type equality so an int allowed-value never matched a
+/// long/double/JsonElement value.
+/// </summary>
+public class ToolValidatorJsonCoercionTests
+{
+    private readonly ToolValidator _validator = new();
+
+    private static JsonElement Json(string raw) => JsonDocument.Parse(raw).RootElement.Clone();
+
+    [Fact]
+    public void BooleanFromJsonElement_IsAccepted()
+    {
+        var defs = new List<ToolParameter> { new() { Name = "flag", Type = "boolean", Required = true } };
+        var parameters = new Dictionary<string, object?> { ["flag"] = Json("true") };
+
+        _validator.ValidateParameters(parameters, defs).IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void NumberFromJsonElement_RespectsIntegerAndRange()
+    {
+        var defs = new List<ToolParameter>
+        {
+            new() { Name = "count", Type = "integer", Required = true, MinValue = 1, MaxValue = 10 }
+        };
+
+        _validator.ValidateParameters(new Dictionary<string, object?> { ["count"] = Json("5") }, defs)
+            .IsValid.Should().BeTrue();
+
+        // 5.5 is not an integer
+        _validator.ValidateParameters(new Dictionary<string, object?> { ["count"] = Json("5.5") }, defs)
+            .IsValid.Should().BeFalse();
+
+        // 99 is out of range
+        _validator.ValidateParameters(new Dictionary<string, object?> { ["count"] = Json("99") }, defs)
+            .IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void StringFromJsonElement_IsAccepted()
+    {
+        var defs = new List<ToolParameter> { new() { Name = "name", Type = "string", Required = true } };
+        var parameters = new Dictionary<string, object?> { ["name"] = Json("\"hello\"") };
+
+        _validator.ValidateParameters(parameters, defs).IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void AllowedValues_MatchAcrossNumericTypes()
+    {
+        var defs = new List<ToolParameter>
+        {
+            new() { Name = "n", Type = "integer", Required = true, AllowedValues = new object[] { 1, 2, 3 } }
+        };
+
+        // value arrives as a long (JsonElement number) but allowed-values are ints — must still match.
+        _validator.ValidateParameters(new Dictionary<string, object?> { ["n"] = Json("2") }, defs)
+            .IsValid.Should().BeTrue();
+
+        _validator.ValidateParameters(new Dictionary<string, object?> { ["n"] = Json("4") }, defs)
+            .IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void AllowedValues_MatchStringEnum()
+    {
+        var defs = new List<ToolParameter>
+        {
+            new() { Name = "method", Type = "string", Required = true, AllowedValues = new object[] { "GET", "POST" } }
+        };
+
+        _validator.ValidateParameters(new Dictionary<string, object?> { ["method"] = Json("\"POST\"") }, defs)
+            .IsValid.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
Closes #28.

## Problem
- Parameters deserialized from JSON arrive as `JsonElement`. The validator's checks (`value is not bool`, `value is not string`, …) rejected them, so well-formed JSON input failed validation.
- `AllowedValues.Contains(value)` used default boxed equality, so an `int` allowed-value never matched a `long`/`double`/`JsonElement` value of the same magnitude.

## Fix
- `NormalizeJsonElement` coerces a `JsonElement` to the corresponding CLR type (string/bool/long/double/array) before the type/range/integer checks.
- `AllowedValues` are compared by normalized invariant string, so equal values match across numeric/JSON representations.

**Follow-up:** the validator-vs-`Activator` constructor mismatch (finding 21.3) is left separate.

## Tests
`ToolValidatorJsonCoercionTests`: JSON bool/string/number accepted, integer/range enforced on JSON numbers, and `AllowedValues` matches across numeric types and string enums. Full suite: **947 passing**.

> Stacked on #27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)