### PR TITLE
fix: remove startup races in ToolRegistry and PermissionProfileService (#29)

### DIFF
--- a/src/Andy.Tools/Core/PermissionProfileService.cs
+++ b/src/Andy.Tools/Core/PermissionProfileService.cs
@@ -19,6 +19,7 @@ public class PermissionProfileService : IPermissionProfileService
     private readonly string _profileDirectory;
     private readonly JsonSerializerOptions _jsonOptions;
     private ToolPermissions _currentPermissions;
+    private bool _defaultProfileLoaded;
     private readonly SemaphoreSlim _semaphore = new(1, 1);
 
     /// <summary>
@@ -40,8 +41,9 @@ public class PermissionProfileService : IPermissionProfileService
         // Ensure the profile directory exists
         Directory.CreateDirectory(_profileDirectory);
 
-        // Load default profile if it exists
-        _ = Task.Run(async () => await LoadDefaultProfileAsync());
+        // The persisted "default" profile is loaded lazily on first access (see GetCurrentPermissionsAsync)
+        // rather than via a fire-and-forget Task in the constructor, which raced with the first read and
+        // could expose built-in defaults or a half-applied profile.
     }
 
     /// <inheritdoc />
@@ -50,11 +52,39 @@ public class PermissionProfileService : IPermissionProfileService
         await _semaphore.WaitAsync(cancellationToken);
         try
         {
+            await EnsureDefaultProfileLoadedAsync(cancellationToken);
             return _currentPermissions.Clone();
         }
         finally
         {
             _semaphore.Release();
+        }
+    }
+
+    // Loads the persisted "default" profile once, on first access, while the caller holds the semaphore.
+    // Sets _currentPermissions directly (does NOT call SetCurrentPermissionsAsync, which would re-enter
+    // the semaphore and deadlock). Marked loaded even on failure so it is attempted at most once.
+    private async Task EnsureDefaultProfileLoadedAsync(CancellationToken cancellationToken)
+    {
+        if (_defaultProfileLoaded)
+        {
+            return;
+        }
+
+        _defaultProfileLoaded = true;
+
+        try
+        {
+            if (await ProfileExistsAsync("default", cancellationToken))
+            {
+                var defaultPermissions = await LoadProfileAsync("default", cancellationToken);
+                defaultPermissions.ModifiedAt = DateTimeOffset.UtcNow;
+                _currentPermissions = defaultPermissions;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to load default profile, using built-in defaults");
         }
     }
 
@@ -68,6 +98,8 @@ public class PermissionProfileService : IPermissionProfileService
         {
             permissions.ModifiedAt = DateTimeOffset.UtcNow;
             _currentPermissions = permissions.Clone();
+            // An explicit set supersedes the lazy default-profile load so a later read can't clobber it.
+            _defaultProfileLoaded = true;
 
             _logger.LogInformation("Updated current permissions to profile: {ProfileName}", permissions.ProfileName);
         }
@@ -233,22 +265,6 @@ public class PermissionProfileService : IPermissionProfileService
 
         var profilePath = GetProfilePath(profileName);
         return Task.FromResult(File.Exists(profilePath));
-    }
-
-    private async Task LoadDefaultProfileAsync()
-    {
-        try
-        {
-            if (await ProfileExistsAsync("default"))
-            {
-                var defaultPermissions = await LoadProfileAsync("default");
-                await SetCurrentPermissionsAsync(defaultPermissions);
-            }
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Failed to load default profile on startup, using built-in defaults");
-        }
     }
 
     private static string GetProfileDirectory()

--- a/src/Andy.Tools/Registry/ToolRegistry.cs
+++ b/src/Andy.Tools/Registry/ToolRegistry.cs
@@ -50,12 +50,6 @@ public class ToolRegistry(IToolValidator validator, ILogger<ToolRegistry> logger
             throw new ArgumentException($"Tool metadata validation failed: {errors}", nameof(metadata));
         }
 
-        // Check if tool already exists
-        if (_tools.ContainsKey(metadata.Id))
-        {
-            throw new InvalidOperationException($"Tool with ID '{metadata.Id}' is already registered");
-        }
-
         var registration = new ToolRegistration
         {
             Metadata = metadata,
@@ -66,9 +60,18 @@ public class ToolRegistry(IToolValidator validator, ILogger<ToolRegistry> logger
             RegisteredAt = DateTimeOffset.UtcNow
         };
 
+        // Add atomically and act on the result: the previous code checked ContainsKey outside the lock
+        // and ignored TryAdd's return, so a concurrent duplicate could silently fail to store yet still
+        // log success and raise ToolRegistered.
+        bool added;
         lock (_lockObject)
         {
-            _tools.TryAdd(metadata.Id, registration);
+            added = _tools.TryAdd(metadata.Id, registration);
+        }
+
+        if (!added)
+        {
+            throw new InvalidOperationException($"Tool with ID '{metadata.Id}' is already registered");
         }
 
         _logger.LogInformation("Registered tool '{ToolName}' (ID: {ToolId}) from factory", metadata.Name, metadata.Id);
@@ -109,7 +112,9 @@ public class ToolRegistry(IToolValidator validator, ILogger<ToolRegistry> logger
             {
                 try
                 {
-                    _ = tempInstance.DisposeAsync();
+                    // Await disposal: the metadata-probe instance may do real async cleanup. Fire-and-forget
+                    // (_ = DisposeAsync()) left it unobserved and possibly incomplete.
+                    tempInstance.DisposeAsync().GetAwaiter().GetResult();
                 }
                 catch (Exception ex)
                 {
@@ -126,12 +131,6 @@ public class ToolRegistry(IToolValidator validator, ILogger<ToolRegistry> logger
             throw new ArgumentException($"Tool metadata validation failed: {errors}");
         }
 
-        // Check if tool already exists
-        if (_tools.ContainsKey(metadata.Id))
-        {
-            throw new InvalidOperationException($"Tool with ID '{metadata.Id}' is already registered");
-        }
-
         var registration = new ToolRegistration
         {
             Metadata = metadata,
@@ -143,9 +142,15 @@ public class ToolRegistry(IToolValidator validator, ILogger<ToolRegistry> logger
             RegisteredAt = DateTimeOffset.UtcNow
         };
 
+        bool added;
         lock (_lockObject)
         {
-            _tools.TryAdd(metadata.Id, registration);
+            added = _tools.TryAdd(metadata.Id, registration);
+        }
+
+        if (!added)
+        {
+            throw new InvalidOperationException($"Tool with ID '{metadata.Id}' is already registered");
         }
 
         _logger.LogInformation("Registered tool '{ToolName}' (ID: {ToolId}) from type {ToolType}",

--- a/tests/Andy.Tools.Tests/Registry/ToolRegistryDuplicateTests.cs
+++ b/tests/Andy.Tools.Tests/Registry/ToolRegistryDuplicateTests.cs
@@ -1,0 +1,42 @@
+using System;
+using Andy.Tools.Core;
+using Andy.Tools.Registry;
+using Andy.Tools.Validation;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Andy.Tools.Tests.Registry;
+
+/// <summary>
+/// Regression test for issue #29: the registry checked ContainsKey outside the lock and ignored
+/// TryAdd's result, so a duplicate could silently fail to store yet still raise ToolRegistered.
+/// </summary>
+public class ToolRegistryDuplicateTests
+{
+    private static ToolMetadata Meta(string id) => new()
+    {
+        Id = id,
+        Name = id,
+        Description = "test",
+        Version = "1.0.0",
+        Category = ToolCategory.Utility
+    };
+
+    [Fact]
+    public void RegisterTool_DuplicateId_ThrowsAndDoesNotRaiseEventTwice()
+    {
+        var registry = new ToolRegistry(new ToolValidator(), NullLogger<ToolRegistry>.Instance);
+        var registeredEvents = 0;
+        registry.ToolRegistered += (_, _) => registeredEvents++;
+
+        ITool Factory(IServiceProvider _) => null!;
+
+        registry.RegisterTool(Meta("dup"), Factory);
+        Action second = () => registry.RegisterTool(Meta("dup"), Factory);
+
+        second.Should().Throw<InvalidOperationException>();
+        registeredEvents.Should().Be(1, "the failed duplicate registration must not raise ToolRegistered");
+        registry.GetTool("dup").Should().NotBeNull();
+    }
+}


### PR DESCRIPTION
Closes #29.

## Fixes
- **ToolRegistry registration race** — the duplicate check used `ContainsKey` *outside* the lock and the `TryAdd` return was ignored, so two threads registering the same id could both pass the check and one would silently fail to store while still logging success and raising `ToolRegistered`. Registration now adds atomically under the lock, throws on a real duplicate, and raises the event only on a successful add.
- **Fire-and-forget probe disposal** — the metadata-probe instance's `DisposeAsync` was discarded (`_ = ...`); it's now awaited.
- **PermissionProfileService startup race** — the constructor launched an unawaited `Task.Run` to load the persisted "default" profile, racing with the first `GetCurrentPermissionsAsync` (which could observe built-in defaults or a half-applied profile). Loading is now lazy on first access under the existing semaphore, and an explicit `SetCurrentPermissionsAsync` supersedes it.

## Tests
`ToolRegistryDuplicateTests`: a duplicate registration throws and does not raise `ToolRegistered` twice. Full suite: **948 passing**.

> Stacked on #28.

🤖 Generated with [Claude Code](https://claude.com/claude-code)