### PR TITLE
fix(output): recognize typed lists and harden truncation (#30)

### DIFF
--- a/src/Andy.Tools/Core/OutputLimiting/ToolOutputLimiter.cs
+++ b/src/Andy.Tools/Core/OutputLimiting/ToolOutputLimiter.cs
@@ -55,8 +55,9 @@ public class ToolOutputLimiter : IToolOutputLimiter
         var size = EstimateSize(output);
         var maxSize = GetMaxSize(outputType);
 
-        // Check if output is a list
-        if (output is IList<object> list)
+        // Check if output is a list. Use the non-generic IList so strongly-typed lists (List<string>,
+        // FileInfo[], ...) are recognized — they are not IList<object> (no generic variance on IList<T>).
+        if (output is System.Collections.IList list)
         {
             return list.Count > GetMaxItems(outputType) || size > maxSize;
         }
@@ -76,23 +77,30 @@ public class ToolOutputLimiter : IToolOutputLimiter
         {
             null => 0,
             string str => Encoding.UTF8.GetByteCount(str),
-            IList<object> list => EstimateListSize(list),
+            System.Collections.IList list => EstimateListSize(list),
             _ => EstimateJsonSize(output)
         };
     }
 
-    private long EstimateListSize(IList<object> list)
+    private long EstimateListSize(System.Collections.IList list)
     {
         long totalSize = 0;
-        foreach (var item in list.Take(1000)) // Sample first 1000 items
+        var sampled = 0;
+        foreach (var item in list) // Sample first 1000 items
         {
+            if (sampled >= 1000)
+            {
+                break;
+            }
+
             totalSize += EstimateSize(item);
+            sampled++;
         }
 
-        if (list.Count > 1000)
+        if (list.Count > 1000 && sampled > 0)
         {
             // Estimate the rest based on average
-            var avgSize = totalSize / 1000;
+            var avgSize = totalSize / sampled;
             totalSize += avgSize * (list.Count - 1000);
         }
 
@@ -448,7 +456,8 @@ public class ToolOutputLimiter : IToolOutputLimiter
         // For structured data, try to preserve structure
         try
         {
-            var truncatedJson = json.Substring(0, context.MaxCharacters ?? _options.MaxOutputCharacters);
+            var cut = Math.Min(json.Length, context.MaxCharacters ?? _options.MaxOutputCharacters);
+            var truncatedJson = json.Substring(0, cut);
             var lastCompleteIndex = FindLastCompleteJsonElement(truncatedJson);
             truncatedJson = truncatedJson.Substring(0, lastCompleteIndex) + "\n... (truncated)";
 
@@ -475,9 +484,22 @@ public class ToolOutputLimiter : IToolOutputLimiter
 
         for (int i = 0; i < json.Length; i++)
         {
-            if (json[i] == '"' && (i == 0 || json[i - 1] != '\\'))
+            if (json[i] == '"')
             {
-                inString = !inString;
+                // A quote is escaped only when preceded by an ODD number of backslashes. The previous
+                // single-char check mis-read "\\\"" (an escaped backslash followed by a real quote).
+                var backslashes = 0;
+                var j = i - 1;
+                while (j >= 0 && json[j] == '\\')
+                {
+                    backslashes++;
+                    j--;
+                }
+
+                if (backslashes % 2 == 0)
+                {
+                    inString = !inString;
+                }
             }
 
             if (!inString)
@@ -564,7 +586,10 @@ public class ToolOutputLimiter : IToolOutputLimiter
             };
         }
 
-        var truncated = text.Substring(0, maxChars - 20) + "\n... (truncated)";
+        // Reserve room for the suffix, but clamp so a small maxChars (< 20) can't produce a negative
+        // length (ArgumentOutOfRangeException). Also never exceed the text length.
+        var keep = Math.Min(text.Length, Math.Max(0, maxChars - 20));
+        var truncated = text.Substring(0, keep) + "\n... (truncated)";
 
         return new LimitedOutput
         {

--- a/tests/Andy.Tools.Tests/Core/OutputLimiting/OutputLimiterTypedListAndJsonTests.cs
+++ b/tests/Andy.Tools.Tests/Core/OutputLimiting/OutputLimiterTypedListAndJsonTests.cs
@@ -1,0 +1,59 @@
+using System.Collections.Generic;
+using Andy.Tools.Core.OutputLimiting;
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Andy.Tools.Tests.Core.OutputLimiting;
+
+/// <summary>
+/// Regression tests for issue #30: strongly-typed lists were not recognized for item-count limiting
+/// (only IList&lt;object&gt; was), and truncation could throw at a tiny MaxCharacters.
+/// </summary>
+public class OutputLimiterTypedListAndJsonTests
+{
+    private readonly ToolOutputLimiter _limiter = new(Options.Create(new ToolOutputLimiterOptions
+    {
+        MaxOutputCharacters = 1000,
+        MaxFileListEntries = 10,
+        MaxFileListCharacters = 100_000
+    }));
+
+    [Fact]
+    public void NeedsLimiting_TypedListExceedingItemCount_ReturnsTrue()
+    {
+        // List<string> is NOT IList<object>; previously this slipped past the item-count check.
+        var list = new List<string>();
+        for (var i = 0; i < 25; i++) { list.Add($"item-{i}"); }
+
+        _limiter.NeedsLimiting(list, OutputType.FileList).Should().BeTrue();
+    }
+
+    [Fact]
+    public void LimitOutput_TinyMaxCharacters_DoesNotThrow()
+    {
+        // maxChars - 20 was negative for small caps, throwing ArgumentOutOfRangeException in Substring.
+        var text = new string('x', 5000);
+        var context = new OutputLimitContext { MaxCharacters = 5 };
+
+        var act = () => _limiter.LimitOutput(text, OutputType.Text, context);
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void LimitOutput_StructuredDataWithEscapedQuotes_DoesNotThrow()
+    {
+        // A string value containing an escaped backslash followed by a quote exercised the broken
+        // single-char escape detection in the JSON truncation path.
+        var data = new Dictionary<string, object?>
+        {
+            ["note"] = new string('a', 2000) + "\\\" trailing",
+            ["more"] = new string('b', 2000)
+        };
+        var context = new OutputLimitContext { MaxCharacters = 100 };
+
+        var act = () => _limiter.LimitOutput(data, OutputType.Text, context);
+        act.Should().NotThrow();
+    }
+}


### PR DESCRIPTION
Closes #30.

## Fixes
- **Typed lists not item-limited** — `NeedsLimiting`/`EstimateSize` tested `IList<object>`, which a `List<string>`/array is **not** (no generic variance on `IList<T>`). They now test the non-generic `System.Collections.IList`, so typed lists are item-count limited instead of slipping through to a full-serialization size estimate.
- **`Substring` throw at small caps** — `maxChars - 20` went negative for a small `MaxCharacters`, throwing `ArgumentOutOfRangeException`. The kept length is now clamped to `[0, text.Length]`, and the structured-data cut is clamped to the string length.
- **Broken JSON escape detection** — `FindLastCompleteJsonElement` now counts consecutive preceding backslashes (a quote is escaped only after an odd count), fixing mis-tracking of `\\"` that could yield malformed truncated JSON.

## Tests
`OutputLimiterTypedListAndJsonTests`: a 25-item `List<string>` needs limiting, a tiny `MaxCharacters` truncation doesn't throw, and structured data containing escaped quotes truncates without throwing. Full suite: **951 passing**.

> Stacked on #29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)