### PR TITLE
docs: sync built-in tool list and tool IDs with the code (#33)

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,31 +136,39 @@ The `examples/Andy.Tools.Examples` project demonstrates all features of Andy Too
 
 ## Built-in Tools
 
+The tools registered by default are defined in `BuiltInToolsExtensions`.
+
 ### File System Tools
-- **ReadFileTool** - Read file contents
-- **WriteFileTool** - Write content to files
-- **DeleteFileTool** - Delete files
-- **CopyFileTool** - Copy files with progress tracking
-- **MoveFileTool** - Move/rename files
-- **ListDirectoryTool** - List directory contents with filtering
+- **ReadFileTool** (`read_file`) - Read file contents
+- **WriteFileTool** (`write_file`) - Write content to files
+- **MoveFileTool** (`move_file`) - Move/rename files
+- **ListDirectoryTool** (`list_directory`) - List directory contents with filtering
+
+> `CopyFileTool` and `DeleteFileTool` exist in the library but are **not registered by default**
+> (commented out in `BuiltInToolsExtensions`). Register them explicitly with
+> `services.AddTool<CopyFileTool>()` / `services.AddTool<DeleteFileTool>()` if you need them.
 
 ### Text Processing Tools
-- **FormatTextTool** - Format text (JSON, XML, etc.)
-- **ReplaceTextTool** - Find and replace text
-- **SearchTextTool** - Search text with regex support
+- **FormatTextTool** (`format_text`) - Format text (JSON, XML, etc.)
+- **ReplaceTextTool** (`replace_text`) - Find and replace text
+- **SearchTextTool** (`search_text`) - Search text with regex support
 
 ### Web Tools
-- **HttpRequestTool** - Make HTTP requests
-- **JsonProcessorTool** - Process JSON data with JSONPath
+- **HttpRequestTool** (`http_request`) - Make HTTP requests
+- **JsonProcessorTool** (`json_processor`) - Process JSON data
 
 ### System Tools
-- **SystemInfoTool** - Get system information
-- **ProcessInfoTool** - Get process information
-- **DateTimeTool** - Date/time operations
-- **EncodingTool** - Encode/decode text (Base64, URL, etc.)
+- **SystemInfoTool** (`system_info`) - Get system information
+- **ProcessInfoTool** (`process_info`) - Get process information
+- **ExecuteCommandTool** (`execute_command`) - Run a shell command (requires process-execution permission)
+
+### Utility Tools
+- **DateTimeTool** (`datetime_tool`) - Date/time operations
+- **EncodingTool** (`encoding_tool`) - Encode/decode/hash text (Base64, URL, etc.)
+- **TodoExecutor** (`todo_executor`) - Manage a todo list
 
 ### Git Tools
-- **GitDiffTool** - Get git diff information
+- **GitDiffTool** (`git_diff`) - Get git diff information
 
 ## Architecture
 

--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -368,7 +368,7 @@ var parameters = new Dictionary<string, object?>
 var result = await executor.ExecuteAsync("process_info", parameters);
 ```
 
-### date_time
+### datetime_tool
 
 Performs date and time operations.
 
@@ -398,15 +398,15 @@ var parameters = new Dictionary<string, object?>
     ["add_value"] = 30,
     ["add_unit"] = "days"
 };
-var result = await executor.ExecuteAsync("date_time", parameters);
+var result = await executor.ExecuteAsync("datetime_tool", parameters);
 ```
 
-### encoding
+### encoding_tool
 
 Encodes and decodes text in various formats.
 
 **Parameters:**
-- `text` (string, required): Text to encode/decode
+- `input_text` (string, required): Text to encode/decode
 - `operation` (string, required): Operation
   - "base64_encode"
   - "base64_decode"
@@ -424,37 +424,10 @@ Encodes and decodes text in various formats.
 ```csharp
 var parameters = new Dictionary<string, object?>
 {
-    ["text"] = "Hello World!",
+    ["input_text"] = "Hello World!",
     ["operation"] = "base64_encode"
 };
-var result = await executor.ExecuteAsync("encoding", parameters);
-```
-
-### environment_variables
-
-Manages environment variables.
-
-**Parameters:**
-- `operation` (string, required): Operation
-  - "get": Get specific variable
-  - "list": List all variables
-  - "set": Set variable value
-- `name` (string, optional): Variable name
-- `value` (string, optional): Variable value (for set)
-
-**Returns:**
-- For "get": `value` of the variable
-- For "list": `variables` dictionary
-- For "set": `previous_value` and `new_value`
-
-**Example:**
-```csharp
-var parameters = new Dictionary<string, object?>
-{
-    ["operation"] = "get",
-    ["name"] = "PATH"
-};
-var result = await executor.ExecuteAsync("environment_variables", parameters);
+var result = await executor.ExecuteAsync("encoding_tool", parameters);
 ```
 
 ## Git Tools


### PR DESCRIPTION
Closes #33.

## Fixes
- **README "Built-in Tools"** now matches `BuiltInToolsExtensions`:
  - `CopyFileTool`/`DeleteFileTool` are flagged as **not registered by default** (commented out in source) with a note on how to add them.
  - Added `ExecuteCommandTool` (`execute_command`) and `TodoExecutor` (`todo_executor`), which **are** registered.
  - Moved `DateTimeTool`/`EncodingTool` under a "Utility Tools" heading; every entry now lists its real tool id.
- **docs/tools-reference.md**: corrected tool ids `date_time` → `datetime_tool` and `encoding` → `encoding_tool`, fixed the encoding `text` → `input_text` parameter, and removed the documented-but-non-existent `environment_variables` tool.

Docs-only.

> Stacked on #32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)